### PR TITLE
iac(api-gateway): Support GCP Api Gateway and Identity Platform

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,9 @@
 	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bookworm",
 	"features": {
 		"ghcr.io/devcontainers-contrib/features/poetry:2": {},
-		"ghcr.io/dhoeric/features/google-cloud-cli:1": {}
+		"ghcr.io/dhoeric/features/google-cloud-cli:1": {},
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
+		"ghcr.io/devcontainers-contrib/features/pulumi:1": {}
 	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -19,8 +19,7 @@ jobs:
     environment: ${{ inputs.target-environment }}
     outputs:
       version-info: ${{ steps.setVersionInfo.outputs.version-info }}
-      backendRestApiURLBase: ${{ steps.pulumi.outputs.cloud_run_url }}
-      resourcesBaseUrl: ${{ steps.pulumi.outputs.resourcesBaseUrl }}
+      backendRestApiURLBase: ${{ steps.pulumi.outputs.apigateway_url }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -60,3 +59,5 @@ jobs:
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
           MONGODB_URI: ${{ secrets.MONGODB_URI }}
+          GCP_OAUTH_CLIENT_ID: ${{ secrets.GCP_OAUTH_CLIENT_ID }}
+          GCP_OAUTH_CLIENT_SECRET: ${{ secrets.GCP_OAUTH_CLIENT_SECRET }}

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -112,8 +112,6 @@ jobs:
           stack-name: tabiya-tech/compass-frontend/${{ inputs.target-environment }}
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-          MONGODB_URI: ${{ secrets.MONGODB_URI }}
-          NEXT_PUBLIC_COMPASS_URL: ${{ inputs.backendRestApiURLBase }}
       - name: Show frontend URL
         run: |
           echo "frontend-url<<${{ steps.pulumi.outputs.bucket_url }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /.idea/
 *.iml
 *.env
+
+credentials*.json

--- a/backend/app/server.py
+++ b/backend/app/server.py
@@ -1,8 +1,10 @@
 import logging
+import base64
 
 from dotenv import load_dotenv
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from app.agent.agent_types import AgentInput, AgentOutput
@@ -158,6 +160,18 @@ async def get_conversation_context(session_id: int):
         # this is the main entry point, so we need to catch all exceptions
         logger.exception(e)
         return {"error": "oops! something went wrong!"}
+
+
+# Temporary REST API EP for returning the incoming authentication information
+# from the request. This is for testing purposes until the UI supports auth
+# and must be removed later.
+@app.get(path="/authinfo",
+         description="Returns the authentication info (JWT token claims)")
+async def _get_auth_info(request: Request):
+    auth_info_b64 = request.headers.get('x-apigateway-api-userinfo')
+    # some python magic
+    auth_info = base64.b64decode(auth_info_b64.encode() + b'==').decode()
+    return JSONResponse(auth_info)
 
 
 if __name__ == "__main__":

--- a/frontend-new/package.json
+++ b/frontend-new/package.json
@@ -2,7 +2,7 @@
   "name": "frontend-new",
   "version": "0.1.0",
   "private": true,
-  "homepage": "/newUI",
+  "homepage": ".",
   "devDependencies": {
     "@chromatic-com/storybook": "^1.4.0",
     "@faker-js/faker": "^8.4.1",

--- a/iac/README.md
+++ b/iac/README.md
@@ -1,15 +1,55 @@
-# Infrastructure as Code
-
-https://www.pulumi.com/ai/answers/15xDqB9xyu6D17Kb297Dfi/configuring-google-cloud-project-with-python
+tes# Infrastructure as Code
+The infrastructure for Compass is managed using [Pulumi](https://www.pulumi.com/). The infrastructure is defined in code and can be deployed to Google Cloud Platform (GCP) using Pulumi. 
 
 ## Prerequisites
+### General
 
 - A recent version of [git](https://git-scm.com/) (e.g. ^2.37 )
 - [Python 3.8 or higher](https://www.python.org/downloads/)
 - [Pulumi CLI](https://www.pulumi.com/docs/install/).
 - [Google Cloud SDK (gcloud)](https://cloud.google.com/sdk/docs/install)
 
+### GCP project setup
 
+To use Pulumi to manage the Compass infrastructure in GCP, the following setup must be performed manually:
+#### Root Project
+
+The root project is used to manage the resources of the target projects where the resources will be created. The root project must be created manually and the service account used to run pulumi must be granted access to the root project. Here are the steps to set up the root project:
+
+- Create a root GCP project (`ROOT-PROJECT-ID`). The same root project can be used to manage the resources of other target projects.
+- The service account used to run pulumi must be granted access to the root project (see the [Target Project](#target-project) section bellow for details on the service account). \
+  The service account must have permissions to use Service Usage API in the root project:
+  - `roles/serviceusage.serviceUsageAdmin`
+- The Service Usage API must be enabled manually using Google Cloud Console in the root project.
+- The root project is specified in the `Pulumi.<ENVIRONMENT>.yaml` file:
+    ```yaml
+    # e.g .Pulumi.dev.yaml
+  
+    gcp_root_project: <ROOT-PROJECT-ID>
+    ```  
+  
+> **Explanation**:
+> When a new GCP project is created, the Service Usage API will be in a disabled state. This API is required for managing (enabling/disabling) other APIs in GCP. If the Service Usage API is disabled, Pulumi will throw an error. The current workaround for this issue is to have a root project with the Service Usage API enabled. Pulumi will then call the Service Usage API of the root project to enable the Service Usage API of the target GCP project where the resources are to be created.
+
+#### Target Project
+The target project is the project where the Compass resources are to be created. The service account used to run pulumi must be created in the target project. The target project must be created manually:
+- Create a new GCP target project (`TARGET-PROJECT-ID`)  
+- Create a service account in the target project and grant it the necessary roles to manage the resources in the target project:
+  - `roles/editor`
+  - `roles/resourcemanager.projectIamAdmin`
+  - `roles/cloudfunctions.admin`
+
+  This is the service account that will be used to run pulumi and manage the resources in the target project. This account should be added to the [Root Project](#root-project) as well.
+  >**Note:** It is important to create the service account in the target project because any subsequent service accounts created via Pulumi using that service account will be created in the project where the initial service account was created. Not doing so will result in service accounts being incorrectly created in projects other than the target project.
+
+- For deploying the firebase authentication via pulumi, the following steps must be performed manually in the target project:
+    - Set up a consent screen in the Google Cloud Console 
+    - Set up an OAuth 2.0 client ID in the Google Cloud Console. \
+      The client ID and client secret used to authenticate the application with Firebase are passed to pulumi as environment variables:
+      ```shell
+      GCP_OAUTH_CLIENT_ID="<GCP_OAUTH_CLIENT_ID>"
+      GCP_OAUTH_CLIENT_SECRET="<GCP_OAUTH_CLIENT_SECRET>"
+      ```
 ## Installation
 In the iac directory, run the following commands:
 
@@ -40,24 +80,43 @@ pip install -r requirements.txt
 > ```
 
 
-## Running the code locally
-
+## Running the Pulumi
 
 Before running the code, you need to configure the Google Cloud SDK to use the credentials of the principal that will manage the infrastructure. That principal should have the necessary roles to manage the infrastructure in the particular project that we target. Also, you need to authenticate with Docker to push the images to the Google Cloud Artifact Registry.
 
-### Roles required for the principal
+See the details in the [Root Project](#root-project) and [Target project](#target-project) for the required roles of the principal. 
 
-The principal used to manage the infrastructure should have the following roles:
+### Authenticate via service account keys (preffered method)
 
-The account should have the following roles:
+Using the [service account credentials, authenticate with Google Cloud](https://cloud.google.com/sdk/gcloud/reference/auth/activate-service-account) is the way preferred when running in a CI/CD environment and the most convenient method for running pulumi locally. 
 
-- `role/editor`
+First activate the service account using the following command, as it is required by the docker daemon to authenticate with Google Cloud Artifact Registry:
 
-### Authenticate with Google Cloud
+ ```shell
+gcloud auth activate-service-account --key-file=<KEY_FILE>
+ ```
 
-There are [multiple ways you can authenticate with Google Cloud](https://cloud.google.com/sdk/gcloud/reference/auth). 
+Then, add credentials to docker:
 
-As a best practice, we recommend using service account impersonation when running the code locally.
+```shell
+# add credentials to docker
+# replace <LOCATION> with the location of the Google Cloud Artifact Registry
+gcloud auth configure-docker <LOCATION>-docker.pkg.dev
+```
+
+Finally, use the service account key file to authenticate with Google Cloud when running pulumi.
+For example, assuming that you have to preview the changes, run the following command:
+ ```shell
+GOOGLE_CREDENTIALS=<KEY_FILE> pulumi preview 
+ ```
+
+### Authenticate with Google Cloud (alternative method)
+
+Besides the service account keys authentication, there are [others ways you can authenticate with Google Cloud](https://cloud.google.com/sdk/gcloud/reference/auth). 
+
+Even though it is best practice to use service account impersonation when running the code locally, it can be cumbersome to set up and use.
+
+Here is how to authenticate to Google Cloud using service account impersonation.
 
 Initially authenticate with your personal Google Cloud account:
 
@@ -72,39 +131,54 @@ Then, impersonate the service account that has the necessary roles to manage the
 > Note:
 > When using service account impersonation, your account should be granted access with the `roles/iam.serviceAccountTokenCreator` to that service account. Ask the project owner to grant you that role.
 
-#### Using the Service account keys (CI/CD)
-Using the [service account credentials, authenticate with Google Cloud](https://cloud.google.com/sdk/gcloud/reference/auth/activate-service-account) is the way preferred when running in a CI/CD environment
-
- ```shell
-gcloud auth activate-service-account <SERVICE_ACCOUNT_EMAIL> --key-file=<KEY_FILE> --project=<PROJECT_ID>
- ```
-
-### Authenticate to Docker
-
-Add credentials to docker:
-
-```shell
-# add credentials to docker
-# replace <LOCATION> with the location of the Google Cloud Artifact Registry
-gcloud auth configure-docker <LOCATION>-docker.pkg.dev
-```
-
-### Running pulumi locally
+### Environment variables
 The deployment requires the following environment variables to be set:
 - `MONGODB_URI`: The URI of the MongoDB instance to use where the ESCO data is stored.
+- `GITHUB_SHA`: GitHub commit SHA that will be used as the docker image label. This does not have to be an actual git commit SHA, but using a static SHA (like `latest`) might have weird consequences (like the service not picking up the latest version).
+- `GCP_OAUTH_CLIENT_ID`: The OAuth client ID used to authenticate the application with Firebase.
+- `GCP_OAUTH_CLIENT_SECRET`: The OAuth client secret used to authenticate the application with Firebase.
 
 It is recommended to use a `.env` file to set the environment variables. Create a `.env` file in the root directory of the project and add the following content:
 
 ```shell
 # .env file
 MONGODB_URI="<URI_TO_MONGODB>"
+GITHUB_SHA="<GIT_COMMIT_SHA>"
+GCP_OAUTH_CLIENT_ID="<GCP_OAUTH_CLIENT_ID>"
+GCP_OAUTH_CLIENT_SECRET="<GCP_OAUTH_CLIENT_SECRET>"
 ```
 
-Run the pulumi code locally, using the appropriate commands. For example, to preview the changes for the dev stack, run the following command:
+## Running Pulumi locally
 
-```shell
-# preview the changes for the dev stack
-pulumi preview --stack dev
-```
+Before running the pulumi code.
+
+
+1. Activate the virtual environment as instructed in the [Installation](#installation) section.
+2. Set up the [Environment Variables](#environment-variables)
+
+3. Ensure that the Docker daemon is running locally.
+
+4. Authenticate with Google Cloud as instructed in [Authenticate via Service Account Keys](#authenticate-via-service-account-keys-preffered-method).
+   ```shell
+    # assuming the service account key file is in a folder named keys in the project's root directory and the key file is named credentials.json
+    gcloud auth activate-service-account --key-file="$(pwd)/keys/credentials.json"
+    # assuming the Google Cloud Artifact Registry is in the us-central1 region
+    gcloud auth configure-docker us-central1-docker.pkg.dev
+   ```
+
+5. Run the pulumi code for the infrastructure part you want to deploy. 
+
+
+For example assuming the `.env` file is in the root directory of the IaC project and the service account key file named `credentials.json` is in a folder named `keys` in the project's root directory, to preview the changes for the `backend` infrastructure of the `dev` environment, run the following command:
+
+ ```shell
+GOOGLE_CREDENTIALS="$(pwd)/keys/credentials.json" pulumi preview -C backend -s dev
+ ```
+
+## Useful links
 
 See the [Pulumi documentation](https://www.pulumi.com/docs/) for more information on how to use Pulumi.
+
+See the [Pulumi GCP provider documentation](https://www.pulumi.com/docs/reference/clouds/gcp/) for more information on how to use the GCP provider.
+
+You can read more about how to configure pulumi with a a google cloud project in python [here](https://www.pulumi.com/ai/answers/15xDqB9xyu6D17Kb297Dfi/configuring-google-cloud-project-with-python)

--- a/iac/backend/Pulumi.dev.yaml
+++ b/iac/backend/Pulumi.dev.yaml
@@ -1,6 +1,5 @@
 config:
-  gcp:project: "compass-dev-418218"
+  gcp:project: "compass-dev-425015"
   gcp:region: "us-central1"
-  backend_repository_name: "compass-docker-repository"
-  backend_image_name: "compass-backend"
   backend_vertex_api_region: "us-central1"
+  gcp_root_project: "compass-dev-root"

--- a/iac/backend/__main__.py
+++ b/iac/backend/__main__.py
@@ -13,9 +13,12 @@ def main():
     pulumi.info(f'Using project:{project}')
     location = config.require("region")
     pulumi.info(f'Using location:{location}')
+    environment = pulumi.get_stack()
+    pulumi.info(f"Using Environment: {environment}")
 
     # Deploy the backend
-    deploy_backend(project, location)
+    deploy_backend(project, location, environment)
+
 
 if __name__ == "__main__":
     main()

--- a/iac/backend/config/gcp_api_gateway_config.yaml
+++ b/iac/backend/config/gcp_api_gateway_config.yaml
@@ -1,0 +1,60 @@
+# openapi2-functions.yaml
+swagger: '2.0'
+info:
+  title: Compass API Gateway Config
+  description: Compass API Gateway Config
+  version: 1.0.0
+schemes:
+  - https
+produces:
+  - application/json
+x-google-backend:
+  address: {1}
+  deadline: 30.0 # 30 seconds as the cloud run container may take a while to start
+securityDefinitions:
+    firebase:
+      authorizationUrl: ""
+      flow: "implicit"
+      type: "oauth2"
+      x-google-issuer: "https://securetoken.google.com/{0}"
+      x-google-jwks_uri: "https://www.googleapis.com/service_accounts/v1/metadata/x509/securetoken@system.gserviceaccount.com"
+      x-google-audiences: "{0}"
+paths:
+  /conversation:
+    get:
+      summary: Chat Conversation
+      operationId: conversation
+      responses:
+        '200':
+          description: A successful response
+          schema:
+            type: string
+  /conversation_context:
+    get:
+      summary: Chat Conversation Context
+      operationId: conversation_context
+      responses:
+        '200':
+          description: A successful response
+          schema:
+            type: string
+  /version:
+    get:
+      summary: Deployed version information
+      operationId: version
+      responses:
+        '200':
+          description: A successful response
+          schema:
+            type: string
+  /authinfo:
+    get:
+      summary: Returns incoming auth information - For testing purposes only
+      operationId: authinfo
+      security:
+        - firebase: []
+      responses:
+        '200':
+          description: A successful response
+          schema:
+            type: string

--- a/iac/backend/deploy_backend.py
+++ b/iac/backend/deploy_backend.py
@@ -1,157 +1,430 @@
+import base64
 import os
-import uuid
+from pathlib import Path
 
 import pulumi
 import pulumi_docker as docker
 import pulumi_gcp as gcp
+import pulumiverse_time as time
+from dataclasses import dataclass
 
 
-def _enable_services(project: str, services_to_enable: list[str]) -> list[gcp.projects.Service]:
-    # return an array of services to be enabled
+@dataclass
+class ProjectBaseConfig:
+    project: str
+    location: str
+    environment: str
+
+
+GCP_API_GATEWAY_CONFIG_FILE = "./config/gcp_api_gateway_config.yaml"
+
+BASE_SERVICES = [
+    # GCP Cloud APIs
+    "cloudapis.googleapis.com",
+    # GCP Cloud Billing
+    "cloudbilling.googleapis.com",
+    # Identity And Access Management - needed for creating Service Accounts
+    "iam.googleapis.com",
+    # GCP Service Control - Required by API Gateway
+    "servicecontrol.googleapis.com",
+    "servicemanagement.googleapis.com",
+]
+
+REQUIRED_SERVICES = [
+    # Required for VertexAI see https://cloud.google.com/vertex-ai/docs/start/cloud-environment
+    "aiplatform.googleapis.com",
+    # GCP API Gateway
+    "apigateway.googleapis.com",
+    # Docker image registry
+    "artifactregistry.googleapis.com",
+    # GCP Cloud Build
+    "cloudbuild.googleapis.com",
+    # Cloud Data Loss Prevention - Required for de-identifying data
+    "dlp.googleapis.com",
+    # Firebase
+    "firebasehosting.googleapis.com",
+    "firebase.googleapis.com",
+    # GCP Identity Platform
+    "identitytoolkit.googleapis.com",
+    # GCP Cloud Run
+    "run.googleapis.com",
+]
+
+
+def _get_resource_name(environment: str, resource: str, type=None):
+    if not type:
+        return f"compass-{environment}-{resource}"
+
+    return f"compass-{environment}-{type}-{resource}"
+
+
+def _get_file_as_string(file: str):
+    return Path(file).read_text()
+
+
+def _enable_services(basic_config: ProjectBaseConfig) -> list[gcp.projects.Service]:
+    # GCP APIs that must be enabled first in order to enable other GCP APIs
+    initial_apis = []
+    # GCP APIs that are required by the GCP services that Compass uses
+    base_services = []
+    # These are the actual services Compass requires, including CI/CD, etc.
     enabled_services = []
 
+    # Service Usage API is used for enabling APIs
+    # Pulumi cannot enable Service Usage API to a project directly as the Service Usage API
+    # must be enabled to enable the API. This is a known limitation of Terraform.
+    # The workaround is to have a separate project - here called "root_project" where the 
+    # Service Usage API is enabled. We will call the root_project's Service Usage API to
+    # enable the Service Usage API of the target project where the Compass will be deployed.
+
+    config = pulumi.Config()
+    root_project = config.require("gcp_root_project")
+
+    gcp_provider = gcp.Provider(
+        "gcp_provider", project=basic_config.project, billing_project=root_project, user_project_override=True
+    )
+
+    service_usage = gcp.projects.Service(
+        _get_resource_name(environment=basic_config.environment, type="service", resource="serviceusage"),
+        project=basic_config.project,
+        service="serviceusage.googleapis.com",
+        opts=pulumi.ResourceOptions(provider=gcp_provider, depends_on=[gcp_provider]),
+        # Do not disable the service when the resource is destroyed
+        # as it requires to disable the dependant services to successfully disable the service.
+        # However, disabling the dependant services may render the project unusable.
+        # For this reason, it is better to keep the service when the resource is destroyed.
+        disable_dependent_services=False,
+        disable_on_destroy=False,
+    )
+
+    initial_apis.append(service_usage)
+
+    # Cloud Resource Manager must be enabled as second API
+    cloud_resource_manager = gcp.projects.Service(
+        _get_resource_name(environment=basic_config.environment, type="service", resource="cloudresourcemanager"),
+        project=basic_config.project,
+        service="cloudresourcemanager.googleapis.com",
+        opts=pulumi.ResourceOptions(depends_on=[service_usage]),
+        # Do not disable the service when the resource is destroyed
+        # as it requires to disable the dependant services to successfully disable the service.
+        # However, disabling the dependant services may render the project unusable.
+        # For this reason, it is better to keep the service when the resource is destroyed.
+        disable_dependent_services=False,
+        disable_on_destroy=False,
+    )
+
+    initial_apis.append(cloud_resource_manager)
+
+    # Compute API must be the 3rd API to be enabled
+    # It takes a while for the compute engine API to be fully enabled. Without the sleep, enabling the other services
+    # fail randomly as the compute engine API seems to be still disabled (although the previous step was successful)
+    compute = gcp.projects.Service(
+        _get_resource_name(environment=basic_config.environment, type="service", resource="compute"),
+        project=basic_config.project,
+        service="compute.googleapis.com",
+        opts=pulumi.ResourceOptions(depends_on=[cloud_resource_manager]),
+        # Do not disable the service when the resource is destroyed
+        # as it requires to disable the dependant services to successfully disable the service.
+        # However, disabling the dependant services may render the project unusable.
+        # For this reason, it is better to keep the service when the resource is destroyed.
+        disable_dependent_services=False,
+        disable_on_destroy=False,
+    )
+
+    initial_apis.append(compute)
+
+    sleep_for_a_while = time.Sleep(
+        "wait120Seconds", create_duration="120s", opts=pulumi.ResourceOptions(depends_on=initial_apis)
+    )
+
+    for service in BASE_SERVICES:
+        srv = gcp.projects.Service(
+            _get_resource_name(environment=basic_config.environment, type="service", resource=service.split(".")[0]),
+            project=basic_config.project,
+            service=service,
+            # Do not disable the service when the resource is destroyed
+            # as it requires to disable the dependant services to successfully disable the service.
+            # However, disabling the dependant services may render the project unusable.
+            # For this reason, it is better to keep the service when the resource is destroyed.
+            disable_dependent_services=False,
+            disable_on_destroy=False,
+            opts=pulumi.ResourceOptions(depends_on=initial_apis + [sleep_for_a_while]),
+        )
+        base_services.append(srv)
+
+    opts = pulumi.ResourceOptions(depends_on=base_services + initial_apis)
+
     # Enable the necessary services
-    for service in services_to_enable:
-        srv = gcp.projects.Service("enabled_services_{0}".format(service.split('.')[0]),
-                                   project=project,
-                                   service=service)
+    for service in REQUIRED_SERVICES:
+        srv = gcp.projects.Service(
+            _get_resource_name(environment=basic_config.environment, type="service", resource=service.split(".")[0]),
+            project=basic_config.project,
+            service=service,
+            opts=opts,
+            # Do not disable the service when the resource is destroyed
+            # as it requires to disable the dependant services to successfully disable the service.
+            # However, disabling the dependant services may render the project unusable.
+            # For this reason, it is better to keep the service when the resource is destroyed.
+            disable_dependent_services=False,
+            disable_on_destroy=False,
+        )
         enabled_services.append(srv)
 
-    return enabled_services
+    return initial_apis + base_services + enabled_services
 
 
-def _create_repository(project: str, location: str, repository_name: str,
-                       dependencies: list[pulumi.Resource]) -> gcp.artifactregistry.Repository:
+"""
+# Set up GCP API Gateway.
+# The API Gateway will route the requests to the Compass Cloudrun instance. Additionally, it will verify the incoming JWT tokens
+# and add a new header x-apigateway-api-userinfo that will contain the JWT claims.
+# The Compass Cloudrun instance is publicly accessible over internet, otherwise it cannot be behind API Gateway.
+# To prevent direct calls to the Compass Cloudrun instance, the Cloudrun instance will require GCP IAM based authentication.
+# A service account with 'roles/run.invoker' permission is created for the API Gateway which will allow it to call the Cloudrun instance.
+"""
+
+
+def _setup_api_gateway(
+        *, basic_config: ProjectBaseConfig, cloudrun: gcp.cloudrunv2.Service, dependencies: list[pulumi.Resource]
+):
+    apigw_service_account = gcp.serviceaccount.Account(
+        resource_name=_get_resource_name(environment=basic_config.environment, resource="api-gateway-sa"),
+        # unclear why the resource name is not used here, something to do with account_id constraints? Link to docs?
+        account_id=f"compassapigwsrvacct{basic_config.environment.replace('-', '')}",
+        project=basic_config.project,
+        display_name=f"Compass API Gateway {basic_config.environment} Service Account",
+        opts=pulumi.ResourceOptions(depends_on=dependencies),
+    )
+
+    apigw_api = gcp.apigateway.Api(
+        resource_name=_get_resource_name(environment=basic_config.environment, resource="api-gateway-api"),
+        api_id=_get_resource_name(environment=basic_config.environment, resource="api-gateway-api"),
+        project=basic_config.project,
+        opts=pulumi.ResourceOptions(depends_on=dependencies),
+    )
+
+    # The GCP API Gateway uses OpenAPI 2.0 yaml files for the configurations.
+    # The yaml must be base64 encoded.
+    apigw_config_yaml = _get_file_as_string(GCP_API_GATEWAY_CONFIG_FILE)
+    apigw_config_yaml = pulumi.Output.format(apigw_config_yaml, basic_config.project, cloudrun.uri)
+
+    apigw_config_yaml_b64encoded = apigw_config_yaml.apply(lambda yaml: base64.b64encode(yaml.encode()).decode())
+
+    apigw_config = gcp.apigateway.ApiConfig(
+        resource_name=_get_resource_name(environment=basic_config.environment, resource="api-gateway-config"),
+        api=apigw_api.api_id,
+        project=basic_config.project,
+        openapi_documents=[
+            gcp.apigateway.ApiConfigOpenapiDocumentArgs(
+                document=gcp.apigateway.ApiConfigOpenapiDocumentDocumentArgs(
+                    path=_get_resource_name(environment=basic_config.environment, resource="api-gateway-config.yaml"),
+                    contents=apigw_config_yaml_b64encoded,
+                ),
+            )
+        ],
+        gateway_config=gcp.apigateway.ApiConfigGatewayConfigArgs(
+            backend_config=gcp.apigateway.ApiConfigGatewayConfigBackendConfigArgs(
+                google_service_account=apigw_service_account.email
+            )
+        ),
+    )
+
+    apigw_gateway = gcp.apigateway.Gateway(
+        resource_name=_get_resource_name(environment=basic_config.environment, resource="api-gateway"),
+        api_config=apigw_config.id,
+        display_name=f"Compass API Gateway {basic_config.environment}",
+        gateway_id=_get_resource_name(environment=basic_config.environment, resource="api-gateway"),
+        project=basic_config.project,
+        region=basic_config.location,
+        opts=pulumi.ResourceOptions(depends_on=dependencies),
+    )
+
+    # Only allow access (roles/run.invoker permission) to apigw_service_account
+    # This prevents the service from being accessed directly from the internet
+    gcp.cloudrun.IamBinding(
+        resource_name=_get_resource_name(environment=basic_config.environment, resource="api-gateway-iam-access"),
+        project=basic_config.project,
+        location=basic_config.location,
+        service=cloudrun.name,
+        role="roles/run.invoker",
+        members=[apigw_service_account.email.apply(lambda email: f"serviceAccount:{email}")],
+        opts=pulumi.ResourceOptions(depends_on=dependencies),
+    )
+
+    pulumi.export("apigateway_url", apigw_gateway.default_hostname.apply(lambda hostname: f"https://{hostname}"))
+    return apigw_gateway
+
+
+"""
+# The gcp.identityplatform cannot be disabled after it has been enabled for a GCP project.
+# This code should work when it is run the first time for a new GCP project.
+# However, if the pulumi stack is removed (pulumi destroy), this code will fail when the stack is re-created (pulumi up)
+# as the identity platform has already been enabled for the project.
+# The solution is to import the identity platform configs to the pulumi projects with the following command
+# $ pulumi import gcp:identityplatform/config:Config default {{project}}
+# where {{project}} is for example auth-poc-422113 or compass-dev-418218.
+# After the resource has been imported to the pulumi stack, the code is able to update the configs again.
+"""
+
+
+def _setup_identity_platform(*, basic_config: ProjectBaseConfig, gateway_uri: pulumi.Output[str],
+                             dependencies: list[pulumi.Resource]):
+    # GCP OAuth clients cannot be created automatically, but must be created from the Google Cloud Console.
+    gcp_oauth_client_id = os.getenv("GCP_OAUTH_CLIENT_ID")
+    gcp_oauth_client_secret = os.getenv("GCP_OAUTH_CLIENT_SECRET")
+
+    # Use name "default" as we may require to import this from GCP
+    default = gcp.identityplatform.Config(
+        "default",
+        authorized_domains=[gateway_uri],
+        mfa=gcp.identityplatform.ConfigMfaArgs(
+            state="DISABLED",
+        ),
+        project=basic_config.project,
+        opts=pulumi.ResourceOptions(depends_on=dependencies),
+    )
+
+    # Enable Google Authentication
+    gcp.identityplatform.DefaultSupportedIdpConfig(
+        _get_resource_name(environment=basic_config.environment, resource="google_idp_config"),
+        client_id=gcp_oauth_client_id,
+        client_secret=gcp_oauth_client_secret,
+        idp_id="google.com",
+        enabled=True,
+        project=basic_config.project,
+        opts=pulumi.ResourceOptions(depends_on=dependencies + [default]),
+    )
+
+
+def _create_repository(
+        basic_config: ProjectBaseConfig, repository_name: str, dependencies: list[pulumi.Resource]
+) -> gcp.artifactregistry.Repository:
     # Create a repository
-    return gcp.artifactregistry.Repository("docker-repository",
-                                           project=project,
-                                           location=location,
-                                           format="DOCKER",
-                                           repository_id=repository_name,
-                                           opts=pulumi.ResourceOptions(depends_on=dependencies)
-                                           )
+    return gcp.artifactregistry.Repository(
+        _get_resource_name(environment=basic_config.environment, resource="docker-repository"),
+        project=basic_config.project,
+        location=basic_config.location,
+        format="DOCKER",
+        repository_id=repository_name,
+        opts=pulumi.ResourceOptions(depends_on=dependencies),
+    )
 
 
 def _build_and_push_image(fully_qualified_image_name: str, dependencies: list[pulumi.Resource]) -> docker.Image:
     # Build and push image to gcr repository
-    image = docker.Image("compass-image",
-                         image_name=fully_qualified_image_name,
-                         build=docker.DockerBuildArgs(context="../../backend", platform="linux/amd64"),
-                         registry=None,  # use gcloud for authentication.
-                         opts=pulumi.ResourceOptions(depends_on=dependencies)
-                         )
+    image = docker.Image(
+        "compass-image",
+        image_name=fully_qualified_image_name,
+        build=docker.DockerBuildArgs(context="../../backend", platform="linux/amd64"),
+        registry=None,  # use gcloud for authentication.
+        opts=pulumi.ResourceOptions(depends_on=dependencies),
+    )
 
     # Digest exported so it's easy to match updates happening in cloud run project
     pulumi.export("digest", image.image_name)
     return image
 
 
-def _get_fully_qualified_image_name(project: str, location: str, repository_name: str, image_name: str, label: str):
-    return f'{location}-docker.pkg.dev/{project}/{repository_name}/{image_name}:{label}'
+def _get_fully_qualified_image_name(basic_config: ProjectBaseConfig, repository_name: str, image_name: str):
+    label = os.getenv("GITHUB_SHA")
+    return f"{basic_config.location}-docker.pkg.dev/{basic_config.project}/{repository_name}/{image_name}:{label}"
 
 
 # Deploy cloud run service
 # See https://cloud.google.com/run/docs/overview/what-is-cloud-run for more information
-def _deploy_cloud_run_service(*, project: str,
-                              location: str,
-                              fully_qualified_image_name: str,
-                              vertex_api_region: str,
-                              dependencies: list[pulumi.Resource]):
+def _deploy_cloud_run_service(
+        *,
+        basic_config: ProjectBaseConfig,
+        fully_qualified_image_name: str,
+        vertex_api_region: str,
+        dependencies: list[pulumi.Resource],
+):
     # See https://cloud.google.com/run/docs/securing/service-identity#per-service-identity for more information
     # Create a service account for the Cloud Run service
-    service_account = gcp.serviceaccount.Account('compass-backend-service-account',
-                                                 account_id='compass-backend-service',
-                                                 display_name=
-                                                 'The dedicated service account for the Compass backend service',
-                                                 project=project,
-                                                 )
+    service_account = gcp.serviceaccount.Account(
+        _get_resource_name(environment=basic_config.environment, resource="backend-sa"),
+        account_id=_get_resource_name(environment=basic_config.environment, resource="backend-sa"),
+        display_name="The dedicated service account for the Compass backend service",
+        project=basic_config.project,
+        opts=pulumi.ResourceOptions(depends_on=dependencies),
+    )
 
     # Assign the necessary roles to the service account for Vertex AI access
-    gcp.projects.IAMBinding('ai-user-binding',
-                            members=[
-                                service_account.email.apply(lambda email: f'serviceAccount:{email}')],
-                            role='roles/aiplatform.user',
-                            project=project,
-                            )
+    gcp.projects.IAMBinding(
+        _get_resource_name(environment=basic_config.environment, resource="ai-user-binding"),
+        members=[service_account.email.apply(lambda email: f"serviceAccount:{email}")],
+        role="roles/aiplatform.user",
+        project=basic_config.project,
+        opts=pulumi.ResourceOptions(depends_on=dependencies),
+    )
 
     # Deploy cloud run service
     mongodb_uri = os.getenv("MONGODB_URI")
     if not mongodb_uri:
         raise ValueError("MONGODB_URI environment variable is not set")
-    service = gcp.cloudrunv2.Service("default",
-                                     name="compass-service",
-                                     project=project,
-                                     location=location,
-                                     ingress="INGRESS_TRAFFIC_ALL",
-                                     template=gcp.cloudrunv2.ServiceTemplateArgs(
-                                         containers=[gcp.cloudrunv2.ServiceTemplateContainerArgs(
-                                             image=fully_qualified_image_name,
-                                             envs=[
-                                                 gcp.cloudrunv2.ServiceTemplateContainerEnvArgs(
-                                                     name="MONGODB_URI",
-                                                     value=mongodb_uri
-                                                 ),
-                                                 gcp.cloudrunv2.ServiceTemplateContainerEnvArgs(
-                                                     name="VERTEX_API_REGION",
-                                                     value=vertex_api_region
-                                                 ),
-                                                 # Add more environment variables here
-                                             ]
-                                         )],
-                                         service_account=service_account.email,
-                                     ),
-                                     opts=pulumi.ResourceOptions(depends_on=dependencies)
-                                     )
-    pulumi.export('cloud_run_url', service.uri)
 
-    # Allow public to access the service without authentication
-    # https://cloud.google.com/run/docs/authenticating/public
-    return gcp.cloudrun.IamBinding("public-access",
-                                   project=project,
-                                   location=location,
-                                   service=service.name,
-                                   role="roles/run.invoker",
-                                   members=["allUsers"],
-                                   opts=pulumi.ResourceOptions(depends_on=dependencies)
-                                   )
+    service = gcp.cloudrunv2.Service(
+        _get_resource_name(environment=basic_config.environment, resource="cloudrun-service"),
+        name=_get_resource_name(environment=basic_config.environment, resource="cloudrun-service"),
+        project=basic_config.project,
+        location=basic_config.location,
+        ingress="INGRESS_TRAFFIC_ALL",
+        template=gcp.cloudrunv2.ServiceTemplateArgs(
+            containers=[
+                gcp.cloudrunv2.ServiceTemplateContainerArgs(
+                    image=fully_qualified_image_name,
+                    envs=[
+                        gcp.cloudrunv2.ServiceTemplateContainerEnvArgs(name="MONGODB_URI", value=mongodb_uri),
+                        gcp.cloudrunv2.ServiceTemplateContainerEnvArgs(
+                            name="VERTEX_API_REGION", value=vertex_api_region
+                        ),
+                        # Add more environment variables here
+                    ],
+                )
+            ],
+            service_account=service_account.email,
+        ),
+        opts=pulumi.ResourceOptions(depends_on=dependencies),
+    )
+    pulumi.export("cloud_run_url", service.uri)
+    return service
 
 
 # export a function build_and_push_image that will be used in the main pulumi program
-def deploy_backend(project: str, location: str):
+def deploy_backend(project: str, location: str, environment: str):
+    basic_config = ProjectBaseConfig(project=project, location=location, environment=environment)
+
     # Get the configuration values from the stack
     config = pulumi.Config()
-    repository_name = config.require("backend_repository_name")
-    pulumi.info(f'Using backend_repository:{repository_name}')
-    image_name = config.require("backend_image_name")
-    pulumi.info(f"Using backend_image_name: {image_name}")
     vertex_api_region = config.require("backend_vertex_api_region")
     pulumi.info(f"Using backend_vertex_api_region: {vertex_api_region}")
+
     # Enable the necessary services for building and pushing the image
-    required_services = ["artifactregistry.googleapis.com",
-                         "cloudbuild.googleapis.com",
-                         "run.googleapis.com",
-                         # Required for listing regions
-                         "compute.googleapis.com",
-                         # Required for VertexAI see https://cloud.google.com/vertex-ai/docs/start/cloud-environment
-                         "aiplatform.googleapis.com",
-                         "cloudresourcemanager.googleapis.com",
-                         # Required for de-identifying data 
-                         "dlp.googleapis.com"
-                         ]
-    services = _enable_services(project, required_services)
+    services = _enable_services(basic_config=basic_config)
+
+    repository_name = _get_resource_name(environment=environment, resource="docker-repository")
+    image_name = _get_resource_name(environment=environment, resource="backend")
 
     # Create an artifact repository
-    repository = _create_repository(project, location, repository_name, services)
+    repository = _create_repository(basic_config, repository_name, services)
 
     # Build and push image to gcr repository
-    label = uuid.uuid4().hex[:6].upper()
-    fully_qualified_image_name = _get_fully_qualified_image_name(project, location, repository_name,
-                                                                 image_name, label)
+    fully_qualified_image_name = _get_fully_qualified_image_name(basic_config, repository_name, image_name)
     image = _build_and_push_image(fully_qualified_image_name, [repository])
 
     # Deploy the image as a cloud run service
-    _deploy_cloud_run_service(project=project,
-                              location=location,
-                              fully_qualified_image_name=fully_qualified_image_name,
-                              vertex_api_region=vertex_api_region,
-                              dependencies=[image])
+    cloud_run = _deploy_cloud_run_service(
+        basic_config=basic_config,
+        fully_qualified_image_name=fully_qualified_image_name,
+        vertex_api_region=vertex_api_region,
+        dependencies=services + [image],
+    )
+
+    api_gateway = _setup_api_gateway(
+        basic_config=basic_config, cloudrun=cloud_run,
+        dependencies=services + [cloud_run]
+    )
+
+    # Setup Google Cloud Identity Platform that provides Firebase based authentications
+    _setup_identity_platform(
+        basic_config=basic_config, gateway_uri=api_gateway.default_hostname, dependencies=services + [api_gateway]
+    )

--- a/iac/frontend/Pulumi.dev.yaml
+++ b/iac/frontend/Pulumi.dev.yaml
@@ -1,4 +1,3 @@
 config:
-  compass-frontend:frontend_bucket_name: compass-frontend-dev-418218
-  gcp:project: "compass-dev-418218"
+  gcp:project: "compass-dev-425015"
   gcp:region: "us-central1"

--- a/iac/frontend/__main__.py
+++ b/iac/frontend/__main__.py
@@ -13,9 +13,12 @@ def main():
     pulumi.info(f'Using project:{project}')
     location = config.require("region")
     pulumi.info(f'Using location:{location}')
+    environment = pulumi.get_stack()
+    pulumi.info(f"Using Environment: {environment}")
 
     # Deploy the frontend
-    deploy_frontend(project, location)
+    deploy_frontend(project, location, environment)
+
 
 if __name__ == "__main__":
     main()

--- a/iac/frontend/deploy_frontend.py
+++ b/iac/frontend/deploy_frontend.py
@@ -2,70 +2,108 @@ import os
 import mimetypes
 import pulumi
 import pulumi_gcp as gcp
+from dataclasses import dataclass
 
-def _enable_services(project: str, services_to_enable: list[str]) -> list[gcp.projects.Service]:
+
+@dataclass
+class ProjectBaseConfig:
+    project: str
+    location: str
+    environment: str
+
+
+def _get_resource_name(*, environment: str, resource: str, type=None):
+    if not type:
+        return f"compass-{environment}-{resource}"
+
+    return f"compass-{environment}-{type}-{resource}"
+
+
+def _enable_services(basic_config: ProjectBaseConfig, services_to_enable: list[str]) -> list[gcp.projects.Service]:
     enabled_services = []
     for service in services_to_enable:
-        srv = gcp.projects.Service(f"enabled_services_{service.split('.')[0]}",
-                                   project=project,
-                                   service=service)
+        srv = gcp.projects.Service(
+            _get_resource_name(environment=basic_config.environment, type="service", resource=service.split(".")[0]),
+            project=basic_config.project,
+            service=service,
+            # Do not disable the service when the resource is destroyed
+            # as it requires to disable the dependant services to successfully disable the service.
+            # However, disabling the dependant services may render the project unusable.
+            # For this reason, it is better to keep the service when the resource is destroyed.
+            disable_dependent_services=False,
+            disable_on_destroy=False,
+        )
         enabled_services.append(srv)
     return enabled_services
 
-def _create_bucket(project: str, bucket_name: str, location: str, dependencies: list[pulumi.Resource]) -> gcp.storage.Bucket:
-    return gcp.storage.Bucket(bucket_name,
-                              project=project,
-                              location=location,
-                              uniform_bucket_level_access=True,
-                              website=gcp.storage.BucketWebsiteArgs(
-                                  main_page_suffix="index.html",
-                                  not_found_page="404.html",
-                              ),
-                              opts=pulumi.ResourceOptions(depends_on=dependencies))
 
-def _upload_directory_to_bucket(bucket_name: str, source_dir: str, prefix: str, dependencies: list[pulumi.Resource]) -> None:
-    for root, _, files in os.walk(source_dir):
+def _create_bucket(basic_config: ProjectBaseConfig, bucket_name: str,
+                   dependencies: list[pulumi.Resource]) -> gcp.storage.Bucket:
+    return gcp.storage.Bucket(
+        _get_resource_name(environment=basic_config.environment, type="bucket", resource=bucket_name),
+        project=basic_config.project,
+        location=basic_config.location,
+        uniform_bucket_level_access=True,
+        website=gcp.storage.BucketWebsiteArgs(
+            main_page_suffix="index.html",
+            not_found_page="404.html",
+        ),
+        opts=pulumi.ResourceOptions(depends_on=dependencies))
+
+
+def _upload_directory_to_bucket(basic_config: ProjectBaseConfig, bucket_name: pulumi.Output, source_dir: str,
+                                target_dir: str,
+                                dependencies: list[pulumi.Resource]) -> None:
+    print(f"Uploading files from folder {os.path.abspath(source_dir)}")
+    for root, _, files in os.walk(source_dir):  # source_dir can be relative or absolute
         for file in files:
-            file_path = os.path.join(root, file)
-            relative_path = os.path.relpath(file_path, source_dir)
-            if prefix:
-                relative_path = os.path.join(prefix, relative_path)
-            mime_type, _ = mimetypes.guess_type(file_path)
-            print(f"Uploading {file_path} as {relative_path} with MIME type {mime_type}")
+
+            absolute_file_path = os.path.abspath(os.path.join(root, file))
+            file_path = os.path.relpath(absolute_file_path, source_dir)
+            mime_type, _ = mimetypes.guess_type(absolute_file_path)
+            target_name = os.path.join(target_dir, file_path)
+            print(f"Uploading {file_path} as {target_name} with MIME type {mime_type}")
+
             gcp.storage.BucketObject(
-                f"{relative_path.replace('/', '_')}",  # Use a unique name for Pulumi resource while preserving the path
-                name=relative_path,  # Set the actual object name in the bucket to match the relative path
+                # Use a unique name for Pulumi resource while preserving the path
+                _get_resource_name(environment=basic_config.environment, type="file",
+                                   resource=target_name.replace("/", '_')),
+                name=target_name,
                 bucket=bucket_name,
-                source=pulumi.FileAsset(file_path),
+                source=pulumi.FileAsset(absolute_file_path),
                 content_type=mime_type,  # Ensure correct MIME type
                 opts=pulumi.ResourceOptions(depends_on=dependencies)
             )
 
-def _make_bucket_public(bucket_name: str, dependencies: list[pulumi.Resource]) -> None:
-    gcp.storage.BucketIAMMember("allUsers-objectViewer",
-                                bucket=bucket_name,
-                                role="roles/storage.objectViewer",
-                                member="allUsers",
-                                opts=pulumi.ResourceOptions(depends_on=dependencies))
 
-def deploy_frontend(project: str, location: str):
-    config = pulumi.Config()
-    bucket_name = config.require("frontend_bucket_name")
-    pulumi.info(f'Using frontend_bucket_name: {bucket_name}')
+def _make_bucket_public(basic_config: ProjectBaseConfig, bucket_name: pulumi.Output,
+                        dependencies: list[pulumi.Resource]) -> None:
+    gcp.storage.BucketIAMMember(
+        _get_resource_name(environment=basic_config.environment, type="BucketIAMMember",
+                           resource="allUsers-objectViewer"),
+        bucket=bucket_name,
+        role="roles/storage.objectViewer",
+        member="allUsers",
+        opts=pulumi.ResourceOptions(depends_on=dependencies)
+    )
 
+
+def deploy_frontend(project: str, location: str, environment: str):
+    basic_config = ProjectBaseConfig(project=project, location=location, environment=environment)
     required_services = ["storage.googleapis.com"]
-    services = _enable_services(project, required_services)
+    services = _enable_services(basic_config, required_services)
 
-    bucket = _create_bucket(project, bucket_name, location, services)
+    bucket = _create_bucket(basic_config, "frontend", services)
 
     frontend_out_dir = "../../frontend/out"
-    _upload_directory_to_bucket(bucket.name, frontend_out_dir, "", [bucket])
+    _upload_directory_to_bucket(basic_config, bucket.name, frontend_out_dir, "", [bucket])
 
     new_ui_build_dir = "../../frontend-new/build"
-    _upload_directory_to_bucket(bucket.name, new_ui_build_dir, "newUI", [bucket])
+    _upload_directory_to_bucket(basic_config, bucket.name, new_ui_build_dir, "new-ui", [bucket])
 
-    _make_bucket_public(bucket.name, [bucket])
+    _make_bucket_public(basic_config, bucket.name, [bucket])
 
     pulumi.export('bucket_name', bucket.name)
     pulumi.export('bucket_url', pulumi.Output.concat("http://", bucket.name, ".storage.googleapis.com/index.html"))
-    pulumi.export('new_ui_url', pulumi.Output.concat("http://", bucket.name, ".storage.googleapis.com/newUI/index.html"))
+    pulumi.export('new_ui_url',
+                  pulumi.Output.concat("http://", bucket.name, ".storage.googleapis.com/new-ui/index.html"))

--- a/iac/requirements.txt
+++ b/iac/requirements.txt
@@ -2,3 +2,4 @@ pulumi>=3.0.0,<4.0.0
 pulumi-gcp>=7.0.0,<8.0.0
 pulumi_docker>=4.5.0,<5.0.0
 python-dotenv>=1.0.1,<1.1.0
+pulumiverse_time>=0.0.17


### PR DESCRIPTION
iac(api-gateway): Support GCP Api Gateway and Identity Platform. The API Gateway will be placed in front of the Compass GCP Cloud Run instance. The Cloud Run instance is protected and cannot be accessed directly over the internet. Identity Platform will be enabled and configured to support Google authentications.

Notes: 
- This requires a parent/root project to exist in GCP. This parent/root project must have Service Usage API enabled as it will be used to enable the GCP project (read: environment) specific Service Usage API. The project id must be set to the Pulumi.<ENV>.yaml files.
- To enable Google authentications, the OAuth client must be created using the GCP Cloud Console as it cannot be created programmatically. The client id and secret must be added to the Pulumi.<ENV>.yaml file.
- After "pulumi destroy", gcp.identityplatform.Config must be imported after "pulumi up". There does not seem to be any workarounds for this at the moment. It's not an huge issue as the "pulumi destroy" won't be used from CI/CD pipelines. If the command is run, it's run locally and the import can be done manually without problems.
- Adding the GCP Global Load Balancer will come in a separate PR.