### PR TITLE
Llm experiences explorer

### DIFF
--- a/backend/app/agent/experiences_explorer_agent.py
+++ b/backend/app/agent/experiences_explorer_agent.py
@@ -255,11 +255,10 @@ class ExperiencesExplorerAgent(SimpleLLMAgent):
 
         # Send the prepared reply to the user
         # TODO: pass the LLM reasoning in case the answer was from an LLM
-        response = AgentOutput(message_for_user=reply_raw, finished=finished,
+        return AgentOutput(message_for_user=reply_raw, finished=finished,
                                agent_type=self._agent_type,
                                reasoning="handwritten code",
                                agent_response_time_in_sec=0.1, llm_stats=[])
-        return response
 
     async def _get_esco_preferred_labels(self, state: ExperiencesAgentState) -> set[str]:
         esco_occupations = set()


### PR DESCRIPTION
This PR addresses COM-283 (Conversation structure)

The previous (rigid, hardcoded) conversation structure is replaced by an LLM prompt.

The conversation flow is as follows:

1. Initialize the past experience agent that through a conversation will identify all the relevant jobs and occupations.
2. Run the entire conversation about occupations until the user has nothing more to say
3. Take the entire conversation and run it through an LLM one more time to get the occupations, dates and places in a unified format so that they can be queried via ESCO but also added to a CV/Skill Portfolio
4. (Next to implement:) Initialize the skill explorer agent with the output of the ESCO search on the output of the previous point to have a discussion with the user that highlights the most relevant skills