### PR TITLE
fix(backend): Improve random session id generation [pulumi up]

### DIFF
--- a/backend/app/users/preferences.py
+++ b/backend/app/users/preferences.py
@@ -31,7 +31,7 @@ async def get_user_preferences(repository: UserPreferenceRepository, user_id: st
 
     # Check if the sessions field is missing or empty, and add a new session if needed
     if 'sessions' not in user or not user['sessions']:
-        session_id = random.randint(1000000000, 9999999999)  # nosec
+        session_id = random.randint(0, (1 << 48) - 1) # nosec
         await repository.update_user_preference({
             "user_id": user_id
         }, {
@@ -55,12 +55,14 @@ async def create_user_preferences(repository: UserPreferenceRepository, user: Us
             status_code=409,
             detail="user already exists"
         )
+    # Generating a 64-bit integer session ID
+    session_id = random.randint(0, (1 << 48) - 1)  # nosec
 
     created = await repository.insert_user_preference({
         "user_id": user.user_id,
         "language": user.language,
         "accepted_tc": user.accepted_tc,
-        "sessions": []
+        "sessions": [session_id]
     })
 
     return {

--- a/frontend-new/src/auth/components/PolicyNotice/DataProtectionPolicy.test.tsx
+++ b/frontend-new/src/auth/components/PolicyNotice/DataProtectionPolicy.test.tsx
@@ -142,6 +142,7 @@ describe("Testing Data Protection Policy component with AuthProvider", () => {
       user_id: givenUser.id,
       language: Language.en,
       accepted_tc: new Date(),
+      sessions: [],
     };
     await waitFor(() => {
       expect(userPreferencesServiceMock.createUserPreferences).toHaveBeenCalledWith(expectedUserPreferenceSpecs);
@@ -198,6 +199,7 @@ describe("Testing Data Protection Policy component with AuthProvider", () => {
       user_id: givenUser.id,
       language: Language.en,
       accepted_tc: new Date(),
+      sessions: [],
     };
 
     await waitFor(() => {

--- a/frontend-new/src/auth/components/PolicyNotice/DataProtectionPolicy.tsx
+++ b/frontend-new/src/auth/components/PolicyNotice/DataProtectionPolicy.tsx
@@ -5,7 +5,7 @@ import { routerPaths } from "src/app/routerPaths";
 import { useSnackbar } from "src/theme/SnackbarProvider/SnackbarProvider";
 import UserPreferencesService from "src/auth/services/UserPreferences/userPreferences.service";
 import { AuthContext } from "src/auth/AuthProvider";
-import { Language, UserPreferenceSpecs } from "src/auth/services/UserPreferences/userPreferences.types";
+import { Language, UserPreference } from "src/auth/services/UserPreferences/userPreferences.types";
 import { ServiceError } from "src/error/error";
 import ErrorConstants from "src/error/error.constants";
 import { StatusCodes } from "http-status-codes";
@@ -49,10 +49,11 @@ const DataProtectionAgreement: React.FC = () => {
         ""
       );
     }
-    const newUserPreferenceSpecs: UserPreferenceSpecs = {
+    const newUserPreferenceSpecs: UserPreference = {
       user_id: user.id,
       language: Language.en,
       accepted_tc: new Date(),
+      sessions: [],
     };
     try {
       await userPreferencesService.createUserPreferences(newUserPreferenceSpecs);

--- a/frontend-new/src/auth/services/UserPreferences/userPreferences.service.test.ts
+++ b/frontend-new/src/auth/services/UserPreferences/userPreferences.service.test.ts
@@ -6,7 +6,7 @@ import { StatusCodes } from "http-status-codes";
 import { ServiceError } from "src/error/error";
 import { setupFetchSpy } from "src/_test_utilities/fetchSpy";
 import ErrorConstants from "src/error/error.constants";
-import { Language, UserPreference, UserPreferenceResponse, UserPreferenceSpecs } from "./userPreferences.types";
+import { Language, UserPreference, UserPreferenceResponse } from "./userPreferences.types";
 import { PersistentStorageService } from "src/persistentStorageService/PersistentStorageService";
 
 // mock the persistent storage service
@@ -146,10 +146,11 @@ describe("UserPreferencesService", () => {
   describe("createUserPreferences", () => {
     test("should fetch the correct URL, with POST and the correct headers and payload successfully", async () => {
       // GIVEN some user preference specification to create
-      const givenUserPreferencesSpec: UserPreferenceSpecs = {
+      const givenUserPreferencesSpec: UserPreference = {
         user_id: "foo",
         language: Language.en,
         accepted_tc: new Date(),
+        sessions: [],
       };
       // AND the create model REST API will respond with OK and some newly create model
       const expectedUserPreferenceResponse = {
@@ -188,10 +189,11 @@ describe("UserPreferencesService", () => {
     });
 
     test("on fail to fetch, it should reject with the expected service error", async () => {
-      const givenUserPreferencesSpec: UserPreferenceSpecs = {
+      const givenUserPreferencesSpec: UserPreference = {
         user_id: "1",
         language: Language.en,
         accepted_tc: new Date(),
+        sessions: [],
       };
       // GIVEN fetch rejects with some unknown error
       const givenFetchError = new Error();
@@ -210,10 +212,11 @@ describe("UserPreferencesService", () => {
       "on 201, should reject with an error ERROR_CODE.INVALID_RESPONSE_BODY if response %s",
       async (description, givenResponse) => {
         // GIVEN some user preference specification to create
-        const givenUserPreferencesSpec: UserPreferenceSpecs = {
+        const givenUserPreferencesSpec: UserPreference = {
           user_id: "1",
           language: Language.en,
           accepted_tc: new Date(),
+          sessions: [],
         };
         // AND the create model REST API will respond with OK and some response that does conform to the userPreferencesResponseSchema even if it states that it is application/json
         setupFetchSpy(StatusCodes.CREATED, givenResponse, "application/json;charset=UTF-8");

--- a/frontend-new/src/auth/services/UserPreferences/userPreferences.service.ts
+++ b/frontend-new/src/auth/services/UserPreferences/userPreferences.service.ts
@@ -1,5 +1,5 @@
 import { getServiceErrorFactory } from "src/error/error";
-import { UserPreference, UserPreferenceResponse, UserPreferenceSpecs } from "./userPreferences.types";
+import { UserPreference, UserPreferenceResponse } from "./userPreferences.types";
 import { StatusCodes } from "http-status-codes";
 import ErrorConstants from "src/error/error.constants";
 import { getBackendUrl } from "src/envService";
@@ -18,7 +18,7 @@ export default class UserPreferencesService {
    * Creates an entry for the user preferences of a user with an ID
    *
    */
-  public async createUserPreferences(newUserPreferencesSpec: UserPreferenceSpecs): Promise<UserPreferenceResponse> {
+  public async createUserPreferences(newUserPreferencesSpec: UserPreference): Promise<UserPreferenceResponse> {
     const serviceName = "UserPreferencesService";
     const serviceFunction = "createUserPreferences";
     const method = "POST";

--- a/frontend-new/src/auth/services/UserPreferences/userPreferences.types.ts
+++ b/frontend-new/src/auth/services/UserPreferences/userPreferences.types.ts
@@ -17,5 +17,3 @@ export type UserPreferenceResponse = {
   user_preference_id: string;
   user_preferences: UserPreference;
 };
-
-export type UserPreferenceSpecs = Omit<UserPreference, "sessions">;


### PR DESCRIPTION
RNG for session id should be generated in a way that will result in fewest conflicts. Also fixes added for sessionId creation when registering for the first time