### PR TITLE
Collect experiences agent initial version

### DIFF
--- a/backend/app/agent/collect_experiences_agent.py
+++ b/backend/app/agent/collect_experiences_agent.py
@@ -5,30 +5,85 @@ from textwrap import dedent
 from app.agent.agent import SimpleLLMAgent
 from app.agent.agent_types import AgentType
 from app.agent.agent_types import AgentInput, AgentOutput
+from app.agent.experience.experience_entity import ExperienceEntity
+from app.tool.extract_experience_data import ExtractExperienceTool
 from app.conversation_memory.conversation_memory_types import \
     ConversationContext
+from common_libs.text_formatters.extract_json import extract_json, ExtractJSONError
 
 logger = logging.getLogger(__name__)
 
 
 def _create_llm_system_instructions() -> str:
-    # TODO: Replace the prompt with a real one (this is just a stub)
-    return dedent(""""You work for an employment agency helping the user outline their previous 
-        experiences and reframe them for the job market. You should be explicit in saying that past experience can 
-        also reflect work in the unseen economy, such as care work for family and this should be included in your 
-        investigation. Keep asking the user if they have more experience they would 
-        like to talk about until they explicitly state that they don't.""")
+    return dedent(""""You work for an employment agency helping users outline their previous experiences and reframe 
+    them for the job market.
+    **Be explicit**: Mention that past experience can include work in the unseen economy, such as caregiving for family,
+    and encourage the user to share those experiences.
+    Your task is finished when the user has no more experiences to share.
+    
+    **Gather details**: For each role, ask for the job title (or description), dates worked, and location.
+    **Be thorough**: Continue asking about experiences until the user explicitly states they have no more to share.
+    **Transition**: Once all experiences are gathered, inform the user that they'll be moving forward to discuss
+    relevant skills. Before this, ask if the user would like to add anything else.
+    **Tone**: Maintain a concise and professional tone, while being polite and empathetic.
+    
+    Your response must always be a JSON object with the following schema:
+        - reasoning: A step by step explanation of how my message relates to your instructions,
+                     why you set the finished flag to the specific value and why you chose the message.
+                     In the form of "..., therefore I will set the finished flag to true|false, and I will ...",
+                     in double quotes formatted as a json string.
+        - finished: A boolean flag to signal that you have completed your task.
+                    Set to true if you have finished your task, false otherwise.
+        - message:  Your message to the user in double quotes formatted as a json string
+        - data: list of dictionaries, one per experience containing
+            {
+                experience_name: name of the experience
+                work_type: type of work, one of 'self-employed', 'unpaid', 'wage work'
+                start_date: The start date in YYYY/MM/DD or YYYY/MM depending on what input I provided
+                end_date: The end date in YYYY/MM//DD or YYYY/MM depending on what input I provided
+                location: The location in which the job was performed.
+            }
+
+    """)
 
 
-class CollectExperiencesAgent(SimpleLLMAgent):
+class CollectExperiencesAgent(SimpleLLMAgent[list[ExperienceEntity]]):
     """
     This agent drives the conversation to build up the initial picture of the previous work experiences of the user.
     This agent is stateless, and it does not link to ESCO.
     """
 
+    async def execute(self, user_input: AgentInput, context: ConversationContext) -> AgentOutput[list[ExperienceEntity]]:
+        output: AgentOutput = await super().execute(user_input, context)
+
+        # TODO: We should not add new experience entities at every conversation turn, because we may still have partial
+        #  information only
+        if output.data:
+            for elem in output.data:
+                try:
+                    entity = ExperienceEntity(experience_title=elem['experience_name'])
+                    # TODO: extract the other fields too. Raise errors if it fails
+                    self._experiences.append(entity)
+                except Exception as e:
+                    logger.debug("Could not parse experience entity from: %s. Error: %s", elem, e)
+
+        if output.finished:
+            # This is a fallback solution, but it works: we run a second LLM if the data was not extracted successfully
+            if not output.data:
+                # TODO: check if the summary is detailed enough for this to work and disable summarization if not
+                self._experiences = await self._extract_experience_tool.extract_experience_data(context.summary)
+
+        return output
+
+    def get_experiences(self) -> list[ExperienceEntity]:
+        return self._experiences
+
     def __init__(self):
         # The system instructions are passed to the llm, together with the common instructions wrt CoT
         system_instructions = _create_llm_system_instructions()
+
+        self._extract_experience_tool = ExtractExperienceTool()
+        self._experiences = []
 
         super().__init__(agent_type=AgentType.COLLECT_EXPERIENCES_AGENT,
                          system_instructions=system_instructions)

--- a/backend/app/agent/explore_experiences_agent_director.py
+++ b/backend/app/agent/explore_experiences_agent_director.py
@@ -17,6 +17,7 @@ from app.conversation_memory.conversation_memory_types import \
     ConversationContext
 from app.vector_search.esco_entities import OccupationSkillEntity
 from app.vector_search.similarity_search_service import SimilaritySearchService
+from app.agent.collect_experiences_agent import CollectExperiencesAgent
 
 logger = logging.getLogger(__name__)
 
@@ -191,7 +192,7 @@ class ExploreExperiencesAgentDirector(Agent):
             if not agent_output.finished:
                 return agent_output
 
-            # Collecting has finished update the state with the experiences
+            # Collecting has finished, update the state with the experiences
             experiences = self._collect_experiences_agent.get_experiences()
             for exp in experiences:
                 s.experiences_state[exp.uuid] = ExperienceState(experience=exp)
@@ -226,7 +227,7 @@ class ExploreExperiencesAgentDirector(Agent):
                          is_responsible_for_conversation_history=True)
         self._conversation_manager = conversation_manager
         self._state: ExploreExperiencesAgentDirectorState | None = None
-        self._collect_experiences_agent = _CollectExperiencesAgentStub()
+        self._collect_experiences_agent = CollectExperiencesAgent()
         self._infer_occupations_agent = _InferOccupationsAgentStub()
         self._exploring_skills_agent = SkillExplorerAgent()
 

--- a/backend/app/tool/extract_experience_data.py
+++ b/backend/app/tool/extract_experience_data.py
@@ -1,0 +1,56 @@
+import logging
+
+from textwrap import dedent
+
+from app.agent.experience.experience_entity import ExperienceEntity
+from app.agent.experience.work_type import WorkType
+from common_libs.llm.generative_models import GeminiGenerativeLLM
+from common_libs.llm.models_utils import LLMConfig, LOW_TEMPERATURE_GENERATION_CONFIG
+
+logger = logging.getLogger(__name__)
+
+
+def extract_work_type(llm_output_field:str) -> WorkType:
+    if "FORMAL" in llm_output_field:
+        return WorkType.FORMAL_SECTOR_WAGED_EMPLOYMENT
+    # TODO: cover all enum values
+    else:
+        return None
+
+
+class ExtractExperienceTool:
+    """
+    This tool takes a user input text and uses an LLM to decide what past experiences is the user talking about.
+    The experience can be a formal work experience (e.g. baker) or an informal experience (e.g. cooking for the family).
+
+    Note that we don't link to ESCO data in this tool.
+    """
+
+    def __init__(self):
+        config:LLMConfig = LLMConfig(generation_config=LOW_TEMPERATURE_GENERATION_CONFIG)
+        # TODO: Consider using json (now we use a CSV-like format) to be consistent with the agents.
+        self._system_instructions = dedent(""" 
+                    Given a conversation between a user and an assistant of an employment agency, list all the 
+                    relevant occupations, places of work, dates and whether it was in the unseen economy or not. The 
+                    format should be:
+
+                    {JOB_TITLE}; {UNSEEN_OR_FORMAL_ECONOMY}; {PLACE_OF_WORK}; {COMPANY}; {DATES_WORKED}
+                    
+                    each variable should be separated by semicolon and each position should be separated by a newline. 
+                    If you are unsure about a variable, return NOT_CLEAR
+              """)
+        self._llm = GeminiGenerativeLLM(system_instructions=self._system_instructions, config=config)
+
+    async def extract_experience_data(self, user_str: str) -> list[ExperienceEntity]:
+        llm_response = await self._llm.generate_content(user_str)
+        response_text = llm_response.text
+        experiences: list[ExperienceEntity] = []
+        for line in response_text.split("\n"):
+            if line.strip() == "":
+                continue
+            elements = line.split(";")
+            experience = ExperienceEntity(experience_title=elements[0])
+            # TODO: extract the other fields too (e.g. work_type, location)
+            # experience.work_type =  extract_work_type(elements[1])
+            experiences.append(experience)
+        return experiences


### PR DESCRIPTION
Replaces the stub implementation.

It is able to extract the experience_title (but not the other data, e.g. location for now.)
The location, timeline, etc will be added in a followup PR.