### PR TITLE
feat(chat): add notifications when a new experiences discovered

### DIFF
--- a/backend/app/chat/chat_types.py
+++ b/backend/app/chat/chat_types.py
@@ -32,6 +32,8 @@ class ConversationResponse(BaseModel):
     """Whether the conversation is finished"""
     conversation_completed_at: Optional[datetime] = None
     """The time the conversation was completed"""
+    experiences_explored: int = 0
+    """The number of experiences explored"""
 
     @field_serializer('conversation_completed_at')
     def serialize_conversation_completed_at(self, value: Optional[datetime]) -> Optional[str]:

--- a/frontend-new/src/chat/Chat.stories.tsx
+++ b/frontend-new/src/chat/Chat.stories.tsx
@@ -195,3 +195,14 @@ export const ShownWhenUserIsInactive: Story = {
     mockData: generateRealisticConversation(false, true),
   },
 };
+
+
+export const ShowWhenNewWxperienceIsDiscovered: Story = {
+  args: {
+    showNewExperienceAlert: true,
+    disableInactivityCheck: false,
+  },
+  parameters: {
+    mockData: generateRealisticConversation(false, true),
+  },
+};

--- a/frontend-new/src/chat/Chat.test.tsx
+++ b/frontend-new/src/chat/Chat.test.tsx
@@ -8,7 +8,7 @@ import { DATA_TEST_ID as EXPERIENCES_DRAWER_HEADER_TEST_ID } from "src/Experienc
 import { DATA_TEST_ID as EXPERIENCES_DRAWER_CONTAINER_TEST_ID } from "src/Experiences/ExperiencesDrawer";
 import { DATA_TEST_ID as APPROVE_MODEL_TEST_ID } from "src/theme/ApproveModal/ApproveModal";
 import { HashRouter } from "react-router-dom";
-import { useSnackbar } from "src/theme/SnackbarProvider/SnackbarProvider";
+import { DEFAULT_SNACKBAR_AUTO_HIDE_DURATION, useSnackbar } from "src/theme/SnackbarProvider/SnackbarProvider";
 import { ConversationMessageSender } from "./ChatService/ChatService.types";
 import { Language } from "src/userPreferences/UserPreferencesService/userPreferences.types";
 import { UserPreferencesContext } from "src/userPreferences/UserPreferencesProvider/UserPreferencesProvider";
@@ -459,6 +459,45 @@ describe("Chat", () => {
         );
       });
     });
+
+    it("should show a message when the message has triggered a new exploration of the skill", async () => {
+      // @ts-ignore
+      useSnackbar().enqueueSnackbar.mockClear();
+
+      // GIVEN: 10 experiences have been explored
+      const givenExploredExperiences = 10;
+
+      // AND: the chat has been initialized
+      mockSendMessage.mockResolvedValue({
+        messages: [],
+        experiences_explored: givenExploredExperiences,
+      })
+
+      // WHEN: the chat is rendered
+      render(
+        <HashRouter>
+          <UserPreferencesContext.Provider value={userPreferencesContextValue}>
+            <Chat />
+          </UserPreferencesContext.Provider>
+        </HashRouter>
+      );
+
+      // AND: a message is sent.
+      const input = screen.getByTestId(CHAT_MESSAGE_FIELD_TEST_ID.CHAT_MESSAGE_FIELD);
+      const sendButton = screen.getByTestId(CHAT_MESSAGE_FIELD_TEST_ID.CHAT_MESSAGE_FIELD_BUTTON);
+
+      fireEvent.change(input, { target: { value: "Test message" } });
+      fireEvent.click(sendButton);
+
+
+      await waitFor(() => {
+        expect(useSnackbar().enqueueSnackbar).toHaveBeenCalledWith(`There is a new experience in your Skills Report.`, {
+          variant: "info",
+          autoHideDuration: DEFAULT_SNACKBAR_AUTO_HIDE_DURATION,
+          action: expect.any(Object),
+        });
+      });
+    })
   });
 
   describe("test user experience drawer", () => {

--- a/frontend-new/src/chat/ChatService/ChatService.types.ts
+++ b/frontend-new/src/chat/ChatService/ChatService.types.ts
@@ -15,4 +15,5 @@ export interface ConverstaionResponse {
   messages: ConversationMessage[];
   conversation_completed: boolean;
   conversation_completed_at: string | null; // ISO formatted datetime string
+  experiences_explored: number; // a count for all the experiences explored (processed)
 }


### PR DESCRIPTION
Add `experiences_explored` field in `ConversationResponse` in `chat_types.py`. 
Update `conversation` API to include the count of processed experiences in `server.py`. 
Modify Chat component in the frontend to show a notification when a new experience is explored. Update Chat tests to verify the new experience notification behavior. 
Add `experiences_explored` property to `ChatService.types.ts`.