### PR TITLE
fix(frontend) - check if dsn is available before setting up sentry

### DIFF
--- a/frontend-new/src/index.test.tsx
+++ b/frontend-new/src/index.test.tsx
@@ -79,6 +79,14 @@ jest.mock("src/app/isOnlineProvider/IsOnlineProvider", () => {
   };
 });
 
+// mock the sentry init
+jest.mock("./sentryInit", () => {
+  return {
+    __esModule: true,
+    initSentry: jest.fn(),
+  };
+});
+
 describe("test the application bootstrapping", () => {
   beforeEach(() => {
     (console.error as jest.Mock).mockClear();

--- a/frontend-new/src/sentryInit.test.ts
+++ b/frontend-new/src/sentryInit.test.ts
@@ -1,3 +1,5 @@
+import "src/_test_utilities/consoleMock"
+
 import * as Sentry from "@sentry/react";
 import { initSentry } from "./sentryInit";
 import { getBackendUrl, getSentryDSN } from "./envService";
@@ -29,6 +31,20 @@ describe("sentryInit", () => {
     // Setup default mock returns
     (getSentryDSN as jest.Mock).mockReturnValue("mock-dsn");
     (getBackendUrl as jest.Mock).mockReturnValue("https://api.example.com");
+  });
+
+  test("should not initialize Sentry if DSN is not available", () => {
+    // GIVEN the DSN is not available
+    (getSentryDSN as jest.Mock).mockReturnValue("");
+
+    // WHEN initSentry is called
+    initSentry();
+
+    // THEN expect Sentry.init not to be called
+    expect(Sentry.init).not.toHaveBeenCalled();
+
+    // AND log a warning message
+    expect(console.warn).toHaveBeenCalledWith("Sentry DSN is not available. Sentry will not be initialized.");
   });
 
   test("should initialize Sentry with correct configuration", () => {

--- a/frontend-new/src/sentryInit.ts
+++ b/frontend-new/src/sentryInit.ts
@@ -8,6 +8,10 @@ import {
 import AuthenticationStateService from "./auth/services/AuthenticationState.service";
 
 export function initSentry() {
+  if(!getSentryDSN()) {
+    console.warn("Sentry DSN is not available. Sentry will not be initialized.");
+    return;
+  }
   Sentry.init({
     dsn: getSentryDSN(),
     integrations: [


### PR DESCRIPTION
fix(backend) - adjust sentry init tests not to be too specific, add test to check that the beforeSend hook is called