### PR TITLE
chore(frontend): use a context for Footer callbacks instead of drilli…

### DIFF
--- a/frontend-new/.storybook/preview.tsx
+++ b/frontend-new/.storybook/preview.tsx
@@ -21,6 +21,7 @@ import type { Preview, StoryFn, StoryObj } from "@storybook/react";
 import SnackbarProvider from "../src/theme/SnackbarProvider/SnackbarProvider";
 import { IsOnlineContext } from "../src/app/isOnlineProvider/IsOnlineProvider";
 import { initSentry } from "../src/sentryInit";
+import { ChatProvider } from "../src/chat/ChatContext";
 
 const preview: Preview = {
   parameters: {
@@ -116,7 +117,9 @@ export const decorators = [
           <ThemeProvider theme={applicationTheme(ThemeMode.LIGHT)}>
             <SnackbarProvider>
               <div style={{ height: "100vh" }}>
-                <Story />
+                <ChatProvider handleOpenExperiencesDrawer={() => {}}>
+                  <Story />
+                </ChatProvider>
               </div>
             </SnackbarProvider>
           </ThemeProvider>

--- a/frontend-new/src/chat/ChatContext.test.tsx
+++ b/frontend-new/src/chat/ChatContext.test.tsx
@@ -1,0 +1,101 @@
+// mute the console
+import "src/_test_utilities/consoleMock";
+
+import { render, screen, renderHook } from "@testing-library/react";
+import { act } from "react-dom/test-utils";
+import { ChatProvider, useChatContext } from "./ChatContext";
+import { FeedbackStatus } from "src/feedback/overallFeedback/feedbackForm/FeedbackForm";
+
+describe("ChatContext", () => {
+  const mockHandleOpenExperiencesDrawer = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("ChatProvider", () => {
+    test("should render children and provide context values", () => {
+      // GIVEN a child component that uses the context
+      const TestChild = () => {
+        const { feedbackStatus, handleOpenExperiencesDrawer } = useChatContext();
+        return (
+          <div data-testid="test-child">
+            <span data-testid="feedback-status">{feedbackStatus}</span>
+            <button data-testid="drawer-button" onClick={handleOpenExperiencesDrawer}>
+              Open Drawer
+            </button>
+          </div>
+        );
+      };
+
+      // WHEN the provider is rendered with the child
+      render(
+        <ChatProvider handleOpenExperiencesDrawer={mockHandleOpenExperiencesDrawer}>
+          <TestChild />
+        </ChatProvider>
+      );
+
+      // THEN expect the child to be rendered
+      const child = screen.getByTestId("test-child");
+      expect(child).toBeInTheDocument();
+
+      // AND expect the initial feedback status to be NOT_STARTED
+      const feedbackStatus = screen.getByTestId("feedback-status");
+      expect(feedbackStatus.textContent).toBe(FeedbackStatus.NOT_STARTED);
+    });
+  });
+
+  describe("useChatContext", () => {
+    test("should throw error when used outside provider", () => {
+      // GIVEN a component that uses the context
+      const TestComponent = () => {
+        useChatContext();
+        return null;
+      };
+
+      // WHEN the component is rendered without the provider
+      // THEN expect it to throw an error
+      expect(() => render(<TestComponent />)).toThrow(
+        "useChatContext must be used within a ChatProvider"
+      );
+    });
+
+    test("should update feedback status", () => {
+      // GIVEN the hook is rendered within the provider
+      const { result } = renderHook(() => useChatContext(), {
+        wrapper: ({ children }) => (
+          <ChatProvider handleOpenExperiencesDrawer={mockHandleOpenExperiencesDrawer}>
+            {children}
+          </ChatProvider>
+        ),
+      });
+
+      // WHEN the feedback status is updated
+      act(() => {
+        result.current.setFeedbackStatus(FeedbackStatus.SUBMITTED);
+      });
+
+      // THEN expect the feedback status to be updated
+      expect(result.current.feedbackStatus).toBe(FeedbackStatus.SUBMITTED);
+    });
+
+    test("should call handleOpenExperiencesDrawer", () => {
+      // GIVEN the hook is rendered within the provider
+      const { result } = renderHook(() => useChatContext(), {
+        wrapper: ({ children }) => (
+          <ChatProvider handleOpenExperiencesDrawer={mockHandleOpenExperiencesDrawer}>
+            {children}
+          </ChatProvider>
+        ),
+      });
+
+      // WHEN handleOpenExperiencesDrawer is called
+      act(() => {
+        result.current.handleOpenExperiencesDrawer();
+      });
+
+      // THEN expect the mock function to be called
+      expect(mockHandleOpenExperiencesDrawer).toHaveBeenCalled();
+    });
+  });
+}); 

--- a/frontend-new/src/chat/ChatContext.tsx
+++ b/frontend-new/src/chat/ChatContext.tsx
@@ -1,0 +1,35 @@
+import { createContext, useContext, ReactNode, useState, useMemo } from 'react';
+import { FeedbackStatus } from 'src/feedback/overallFeedback/feedbackForm/FeedbackForm';
+
+interface ChatContextType {
+  handleOpenExperiencesDrawer: () => void;
+  feedbackStatus: FeedbackStatus;
+  setFeedbackStatus: (status: FeedbackStatus) => void;
+}
+
+const ChatContext = createContext<ChatContextType | undefined>(undefined);
+
+interface ChatProviderProps {
+  children: ReactNode;
+  handleOpenExperiencesDrawer: () => void;
+}
+
+export const ChatProvider: React.FC<ChatProviderProps> = ({ children, handleOpenExperiencesDrawer }) => {
+  const [feedbackStatus, setFeedbackStatus] = useState<FeedbackStatus>(FeedbackStatus.NOT_STARTED);
+
+  const value = useMemo(() => ({
+    handleOpenExperiencesDrawer,
+    feedbackStatus,
+    setFeedbackStatus,
+  }), [feedbackStatus, handleOpenExperiencesDrawer]);
+
+  return <ChatContext.Provider value={value}>{children}</ChatContext.Provider>;
+};
+
+export const useChatContext = () => {
+  const context = useContext(ChatContext);
+  if (context === undefined) {
+    throw new Error('useChatContext must be used within a ChatProvider');
+  }
+  return context;
+}; 

--- a/frontend-new/src/chat/chatList/ChatList.test.tsx
+++ b/frontend-new/src/chat/chatList/ChatList.test.tsx
@@ -13,6 +13,7 @@ import ChatBubble, {
   DATA_TEST_ID as CHAT_BUBBLE_DATA_TEST_ID,
 } from "src/chat/chatMessage/components/chatBubble/ChatBubble";
 import ConversationConclusionChatMessage from "src/chat/chatMessage/conversationConclusionChatMessage/ConversationConclusionChatMessage";
+import { ChatProvider } from "src/chat/ChatContext";
 
 // mock the chat message component
 jest.mock("src/chat/chatMessage/basicChatMessage/BasicChatMessage", () => {
@@ -65,6 +66,8 @@ describe("ChatList", () => {
     jest.clearAllMocks();
   });
 
+  const mockHandleOpenExperiencesDrawer = jest.fn();
+
   test("should render the Chat List and show the appropriate message type for each message", () => {
     // GIVEN a message list
     const givenMessages = [
@@ -97,20 +100,12 @@ describe("ChatList", () => {
         type: ChatMessageType.CONVERSATION_CONCLUSION,
       },
     ];
-    // AND a function to open the feedback form
-    const givenNotifyOpenFeedbackForm = jest.fn();
-    // AND a function to open the experiences drawer
-    const givenNotifyOpenExperiencesDrawer = jest.fn();
 
     // WHEN the chat list is rendered
     render(
-      <ChatList
-        messages={givenMessages}
-        notifyOnFeedbackFormOpen={givenNotifyOpenFeedbackForm}
-        notifyOnExperiencesDrawerOpen={givenNotifyOpenExperiencesDrawer}
-        isFeedbackSubmitted={false}
-        isFeedbackStarted={false}
-      />
+      <ChatProvider handleOpenExperiencesDrawer={mockHandleOpenExperiencesDrawer}>
+        <ChatList messages={givenMessages} />
+      </ChatProvider>
     );
 
     // THEN expect the chat list container to be visible
@@ -157,10 +152,6 @@ describe("ChatList", () => {
       1,
       {
         chatMessage: givenMessages[3],
-        notifyOnFeedbackFormOpen: givenNotifyOpenFeedbackForm,
-        notifyOnExperiencesDrawerOpen: givenNotifyOpenExperiencesDrawer,
-        isFeedbackSubmitted: false,
-        isFeedbackStarted: false,
       },
       {}
     );
@@ -192,13 +183,7 @@ describe("ChatList", () => {
     ];
     // AND the chat list is rendered
     render(
-      <ChatList
-        messages={givenMessages}
-        notifyOnFeedbackFormOpen={jest.fn()}
-        notifyOnExperiencesDrawerOpen={jest.fn()}
-        isFeedbackSubmitted={false}
-        isFeedbackStarted={false}
-      />
+      <ChatList messages={givenMessages}/>
     );
 
     // WHEN the window is resized

--- a/frontend-new/src/chat/chatList/ChatList.tsx
+++ b/frontend-new/src/chat/chatList/ChatList.tsx
@@ -14,10 +14,6 @@ export const DATA_TEST_ID = {
 
 export type ChatListProps = {
   messages: IChatMessage[];
-  notifyOnFeedbackFormOpen: () => void;
-  notifyOnExperiencesDrawerOpen: () => void;
-  isFeedbackSubmitted: boolean;
-  isFeedbackStarted: boolean;
 };
 
 const ChatListContainer = styled(Box)(({ theme }) => ({
@@ -35,10 +31,6 @@ const ChatListContainer = styled(Box)(({ theme }) => ({
 
 const ChatList: React.FC<ChatListProps> = ({
   messages,
-  notifyOnFeedbackFormOpen,
-  notifyOnExperiencesDrawerOpen,
-  isFeedbackSubmitted,
-  isFeedbackStarted,
 }) => {
   const theme = useTheme();
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
@@ -80,10 +72,6 @@ const ChatList: React.FC<ChatListProps> = ({
         return (
           <ConversationConclusionChatMessage
             chatMessage={chatMessage}
-            notifyOnFeedbackFormOpen={notifyOnFeedbackFormOpen}
-            notifyOnExperiencesDrawerOpen={notifyOnExperiencesDrawerOpen}
-            isFeedbackSubmitted={isFeedbackSubmitted}
-            isFeedbackStarted={isFeedbackStarted}
           />
         );
       case ChatMessageType.TYPING:

--- a/frontend-new/src/chat/chatMessage/conversationConclusionChatMessage/ConversationConclusionChatMessage.stories.tsx
+++ b/frontend-new/src/chat/chatMessage/conversationConclusionChatMessage/ConversationConclusionChatMessage.stories.tsx
@@ -3,19 +3,33 @@ import ConversationConclusionChatMessage from "src/chat/chatMessage/conversation
 import { ConversationMessageSender } from "src/chat/ChatService/ChatService.types";
 import { ChatMessageType } from "src/chat/Chat.types";
 import { nanoid } from "nanoid";
-import { action } from "@storybook/addon-actions";
+import { ChatProvider, useChatContext } from "src/chat/ChatContext";
+import { FeedbackStatus } from "src/feedback/overallFeedback/feedbackForm/FeedbackForm";
+import { useEffect } from "react";
+
+const withChatContext = (feedbackStatus: FeedbackStatus) => (Story: any) => {
+  const Wrapper = () => {
+    const { setFeedbackStatus } = useChatContext();
+    
+    useEffect(() => {
+      setFeedbackStatus(feedbackStatus);
+    }, [setFeedbackStatus]);
+
+    return <Story />;
+  };
+
+  return (
+    <ChatProvider handleOpenExperiencesDrawer={() => {}}>
+      <Wrapper />
+    </ChatProvider>
+  );
+};
 
 const meta: Meta<typeof ConversationConclusionChatMessage> = {
   title: "Chat/ChatMessage/ConversationConclusion",
   component: ConversationConclusionChatMessage,
   tags: ["autodocs"],
   argTypes: {},
-  args: {
-    notifyOnFeedbackFormOpen: action("Feedback Form opened"),
-    notifyOnExperiencesDrawerOpen: action("Experiences Drawer opened"),
-    isFeedbackSubmitted: false,
-    isFeedbackStarted: false,
-  },
 };
 
 export default meta;
@@ -79,9 +93,9 @@ export const FeedbackInProgress: Story = {
       sent_at: new Date().toISOString(),
       message: "It was great exploring your skills with you! I hope you found this session helpful. Goodbye!",
       type: ChatMessageType.CONVERSATION_CONCLUSION,
-    },
-    isFeedbackStarted: true,
+    }
   },
+  decorators: [withChatContext(FeedbackStatus.STARTED)],
 };
 
 export const FeedbackSubmitted: Story = {
@@ -93,6 +107,6 @@ export const FeedbackSubmitted: Story = {
       message: "It was great exploring your skills with you! I hope you found this session helpful. Goodbye!",
       type: ChatMessageType.CONVERSATION_CONCLUSION,
     },
-    isFeedbackSubmitted: true,
   },
+  decorators: [withChatContext(FeedbackStatus.SUBMITTED)],
 };

--- a/frontend-new/src/chat/chatMessage/conversationConclusionChatMessage/ConversationConclusionChatMessage.test.tsx
+++ b/frontend-new/src/chat/chatMessage/conversationConclusionChatMessage/ConversationConclusionChatMessage.test.tsx
@@ -3,7 +3,7 @@ import "src/_test_utilities/consoleMock";
 
 import ConversationConclusionChatMessage, { DATA_TEST_ID } from "./ConversationConclusionChatMessage";
 import ConversationConclusionFooter from "src/chat/chatMessage/conversationConclusionChatMessage/conversationConclusionFooter/ConversationConclusionFooter";
-import ChatBubble, {
+import {
   DATA_TEST_ID as CHAT_BUBBLE_DATA_TEST_ID,
 } from "src/chat/chatMessage/components/chatBubble/ChatBubble";
 import { render, screen } from "src/_test_utilities/test-utils";
@@ -16,7 +16,7 @@ jest.mock("src/chat/chatMessage/components/chatBubble/ChatBubble", () => {
   return {
     __esModule: true,
     ...originalModule,
-    default: jest.fn(() => <div data-testid={originalModule.DATA_TEST_ID.CHAT_MESSAGE_BUBBLE_CONTAINER}></div>),
+    default: jest.fn(({children}) => <div data-testid={originalModule.DATA_TEST_ID.CHAT_MESSAGE_BUBBLE_CONTAINER}>{children}</div>),
   };
 });
 
@@ -37,6 +37,9 @@ jest.mock(
 );
 
 describe("render tests", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  })
   test("should render the Chat message", () => {
     // GIVEN a basic chat message sent at a given time
     const givenDate = new Date().toISOString();
@@ -45,21 +48,13 @@ describe("render tests", () => {
       sender: ConversationMessageSender.COMPASS,
       message: "Thanks for having a conversation with me.",
       sent_at: givenDate,
-      type: ChatMessageType.CONVERSATION_CONCLUSION, // This component is designed for use with the Conversation conclusion chat type
+      type: ChatMessageType.CONVERSATION_CONCLUSION,
     };
-    // AND a callback to notify when the feedback form is opened
-    const givenNotifyOnFeedbackFormOpen = jest.fn();
-    // AND a callback to notify when the experiences drawer is opened
-    const givenNotifyOnExperiencesDrawerOpen = jest.fn();
 
     // WHEN the conversation conclusion chat message is rendered
     render(
       <ConversationConclusionChatMessage
         chatMessage={givenMessage}
-        notifyOnFeedbackFormOpen={givenNotifyOnFeedbackFormOpen}
-        notifyOnExperiencesDrawerOpen={givenNotifyOnExperiencesDrawerOpen}
-        isFeedbackSubmitted={false}
-        isFeedbackStarted={false}
       />
     );
 
@@ -69,28 +64,53 @@ describe("render tests", () => {
     expect(screen.getByTestId(CHAT_BUBBLE_DATA_TEST_ID.CHAT_MESSAGE_BUBBLE_CONTAINER)).toBeInTheDocument();
 
     // AND expect the conversation conclusion footer to be visible
-    const call = (ChatBubble as jest.Mock).mock.calls.at(-1)[0];
-    expect(call.children).toEqual(
-      expect.objectContaining({
-        type: ConversationConclusionFooter,
-        props: expect.objectContaining({
-          notifyOnFeedbackFormOpen: givenNotifyOnFeedbackFormOpen,
-          notifyOnExperiencesDrawerOpen: givenNotifyOnExperiencesDrawerOpen,
-          isFeedbackSubmitted: false,
-          isFeedbackStarted: false,
-        }),
-      })
-    );
-
-    // AND expect the Chat bubble to have been rendered with the expected message
-    expect(call).toEqual(
-      expect.objectContaining({
-        message: givenMessage.message,
-        sender: givenMessage.sender,
-      })
-    );
+    expect(ConversationConclusionFooter).toHaveBeenCalledTimes(1);
 
     // AND expect the component to match the snapshot
     expect(screen.getByTestId(DATA_TEST_ID.CONVERSATION_CONCLUSION_CHAT_MESSAGE_CONTAINER)).toMatchSnapshot();
+  });
+
+  test("should render with feedback in progress", () => {
+    // GIVEN a basic chat message sent at a given time
+    const givenDate = new Date().toISOString();
+    const givenMessage: IChatMessage = {
+      id: nanoid(),
+      sender: ConversationMessageSender.COMPASS,
+      message: "Thanks for having a conversation with me.",
+      sent_at: givenDate,
+      type: ChatMessageType.CONVERSATION_CONCLUSION,
+    };
+
+    // WHEN the conversation conclusion chat message is rendered
+    render(
+      <ConversationConclusionChatMessage
+        chatMessage={givenMessage}
+      />
+    );
+
+    // THEN expect the conversation conclusion footer to be visible
+    expect(ConversationConclusionFooter).toHaveBeenCalledTimes(1);
+  });
+
+  test("should render with feedback submitted", () => {
+    // GIVEN a basic chat message sent at a given time
+    const givenDate = new Date().toISOString();
+    const givenMessage: IChatMessage = {
+      id: nanoid(),
+      sender: ConversationMessageSender.COMPASS,
+      message: "Thanks for having a conversation with me.",
+      sent_at: givenDate,
+      type: ChatMessageType.CONVERSATION_CONCLUSION,
+    };
+
+    // WHEN the conversation conclusion chat message is rendered
+    render(
+        <ConversationConclusionChatMessage
+          chatMessage={givenMessage}
+        />
+    );
+
+    // THEN expect the conversation conclusion footer to be visible
+    expect(ConversationConclusionFooter).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend-new/src/chat/chatMessage/conversationConclusionChatMessage/ConversationConclusionChatMessage.tsx
+++ b/frontend-new/src/chat/chatMessage/conversationConclusionChatMessage/ConversationConclusionChatMessage.tsx
@@ -10,20 +10,12 @@ export const DATA_TEST_ID = {
   CONVERSATION_CONCLUSION_CHAT_MESSAGE_CONTAINER: `conversation_conclusion_chat-message-container-${uniqueId}`,
 };
 
-type ConversationConclusionChatMessageProps = {
+interface ConversationConclusionChatMessageProps {
   chatMessage: IChatMessage;
-  notifyOnFeedbackFormOpen: () => void;
-  notifyOnExperiencesDrawerOpen: () => void;
-  isFeedbackSubmitted: boolean;
-  isFeedbackStarted: boolean;
-};
+}
 
 const ConversationConclusionChatMessage: React.FC<ConversationConclusionChatMessageProps> = ({
   chatMessage,
-  notifyOnFeedbackFormOpen,
-  notifyOnExperiencesDrawerOpen,
-  isFeedbackSubmitted,
-  isFeedbackStarted,
 }) => {
   return (
     <MessageContainer
@@ -31,12 +23,7 @@ const ConversationConclusionChatMessage: React.FC<ConversationConclusionChatMess
       data-testid={DATA_TEST_ID.CONVERSATION_CONCLUSION_CHAT_MESSAGE_CONTAINER}
     >
       <ChatBubble message={chatMessage.message} sender={chatMessage.sender}>
-        <ConversationConclusionFooter
-          notifyOnFeedbackFormOpen={notifyOnFeedbackFormOpen}
-          notifyOnExperiencesDrawerOpen={notifyOnExperiencesDrawerOpen}
-          isFeedbackSubmitted={isFeedbackSubmitted}
-          isFeedbackStarted={isFeedbackStarted}
-        />
+        <ConversationConclusionFooter />
       </ChatBubble>
     </MessageContainer>
   );

--- a/frontend-new/src/chat/chatMessage/conversationConclusionChatMessage/__snapshots__/ConversationConclusionChatMessage.test.tsx.snap
+++ b/frontend-new/src/chat/chatMessage/conversationConclusionChatMessage/__snapshots__/ConversationConclusionChatMessage.test.tsx.snap
@@ -8,6 +8,10 @@ exports[`render tests should render the Chat message 1`] = `
 >
   <div
     data-testid="chat-message-bubble-container-6e685eeb-2b54-432a-8b66-8a81633b3981"
-  />
+  >
+    <div
+      data-testid="feedback-form-button-container-41675f8b-257c-4a63-9563-3fe9feb6a850"
+    />
+  </div>
 </div>
 `;

--- a/frontend-new/src/chat/chatMessage/conversationConclusionChatMessage/conversationConclusionFooter/ConversationConclusionFooter.test.tsx
+++ b/frontend-new/src/chat/chatMessage/conversationConclusionChatMessage/conversationConclusionFooter/ConversationConclusionFooter.test.tsx
@@ -2,140 +2,166 @@
 import "src/_test_utilities/consoleMock";
 
 import { render, screen } from "src/_test_utilities/test-utils";
-import { FeedbackItem } from "src/feedback/overallFeedback/overallFeedbackService/OverallFeedback.service.types";
 import ConversationConclusionFooter, {
   DATA_TEST_ID,
 } from "src/chat/chatMessage/conversationConclusionChatMessage/conversationConclusionFooter/ConversationConclusionFooter";
 import userEvent from "@testing-library/user-event";
+import UserPreferencesStateService from "src/userPreferences/UserPreferencesStateService";
+import { ChatProvider } from "src/chat/ChatContext";
+import { PersistentStorageService } from "src/app/PersistentStorageService/PersistentStorageService";
+import { FeedbackItem } from "src/feedback/overallFeedback/overallFeedbackService/OverallFeedback.service.types";
 
-// mock the PersistentStorageService
-jest.mock("src/app/PersistentStorageService/PersistentStorageService", () => {
-  const mockUserFeedback: FeedbackItem = {
-    question_id: "recommendation",
-    answer: {
-      rating_numeric: 7,
-    },
-    is_answered: true,
-  };
-  return {
-    __esModule: true,
-    PersistentStorageService: {
-      getOverallFeedback: () => [mockUserFeedback],
-    },
-  };
-});
+// Mock external dependencies
+jest.mock("src/app/PersistentStorageService/PersistentStorageService");
 
-describe("FeedbackFormButton", () => {
-  test("should render component successfully", () => {
-    // GIVEN a FeedbackFormButton component
-    const givenComponent = (
-      <ConversationConclusionFooter
-        notifyOnFeedbackFormOpen={jest.fn()}
-        notifyOnExperiencesDrawerOpen={jest.fn()}
-        isFeedbackSubmitted={false}
-        isFeedbackStarted={false}
-      />
+describe("ConversationConclusionFooter", () => {
+  const givenMockHandleOpenExperiencesDrawer = jest.fn();
+  const givenMockSetFeedbackStatus = jest.fn();
+
+  const renderWithProvider = (component: React.ReactElement) => {
+    return render(
+      <ChatProvider 
+        handleOpenExperiencesDrawer={givenMockHandleOpenExperiencesDrawer}
+      >
+        {component}
+      </ChatProvider>
     );
+  };
 
-    // WHEN the component is rendered
-    render(givenComponent);
-
-    // THEN expect no errors or warning to have occurred
-    expect(console.error).not.toHaveBeenCalled();
-    expect(console.warn).not.toHaveBeenCalled();
-    // AND the feedback form button container to be displayed
-    const feedbackFormButtonContainer = screen.getByTestId(DATA_TEST_ID.FEEDBACK_FORM_BUTTON);
-    expect(feedbackFormButtonContainer).toBeInTheDocument();
-    // AND the feedback form button to be displayed
-    expect(screen.getByTestId(DATA_TEST_ID.FEEDBACK_FORM_BUTTON)).toBeInTheDocument();
-    // AND the feedback message to be displayed
-    expect(screen.getByTestId(DATA_TEST_ID.FEEDBACK_MESSAGE_TEXT)).toBeInTheDocument();
-    // AND the experiences drawer button to be displayed
-    expect(screen.getByTestId(DATA_TEST_ID.EXPERIENCES_DRAWER_BUTTON)).toBeInTheDocument();
-    // AND the component to match the snapshot
-    expect(feedbackFormButtonContainer).toMatchSnapshot();
+  beforeEach(() => {
+    // GIVEN clean mocks before each test
+    jest.clearAllMocks();
+    
+    // AND mock storage service
+    (PersistentStorageService.getOverallFeedback as jest.Mock).mockReturnValue([]);
   });
 
-  test("should call notifyOnExperiencesDrawerOpen when experiences drawer button is clicked", async () => {
-    // GIVEN a FeedbackFormButton component
-    const notifyOnExperiencesDrawerOpen = jest.fn();
-    const givenComponent = (
-      <ConversationConclusionFooter
-        notifyOnFeedbackFormOpen={jest.fn()}
-        notifyOnExperiencesDrawerOpen={notifyOnExperiencesDrawerOpen}
-        isFeedbackSubmitted={false}
-        isFeedbackStarted={false}
-      />
-    );
+  test("should render component successfully", () => {
+    // GIVEN a ConversationConclusionFooter component
+    const givenComponent = <ConversationConclusionFooter />;
+    
+    // AND the user has not submitted feedback before
+    jest.spyOn(UserPreferencesStateService.getInstance(), "activeSessionHasFeedback").mockReturnValueOnce(false);
 
     // WHEN the component is rendered
-    render(givenComponent);
+    renderWithProvider(givenComponent);
 
-    // WHEN the experiences drawer button is clicked
+    // THEN expect no errors or warnings to have occurred
+    expect(console.error).not.toHaveBeenCalled();
+    expect(console.warn).not.toHaveBeenCalled();
+    
+    // AND expect the feedback form button container to be displayed
+    const actualFeedbackFormButtonContainer = screen.getByTestId(DATA_TEST_ID.CONVERSATION_CONCLUSION_FOOTER_CONTAINER);
+    expect(actualFeedbackFormButtonContainer).toBeInTheDocument();
+    
+    // AND expect the feedback message to be displayed
+    expect(screen.getByTestId(DATA_TEST_ID.FEEDBACK_MESSAGE_TEXT)).toBeInTheDocument();
+    
+    // AND expect the experiences drawer button to be displayed
+    expect(screen.getByTestId(DATA_TEST_ID.EXPERIENCES_DRAWER_BUTTON)).toBeInTheDocument();
+    
+    // AND expect the component to match the snapshot
+    expect(actualFeedbackFormButtonContainer).toMatchSnapshot();
+  });
+
+  test("should open experiences drawer when experiences drawer button is clicked", async () => {
+    // GIVEN a ConversationConclusionFooter component
+    const givenComponent = <ConversationConclusionFooter />;
+    
+    // AND the user has not submitted feedback before
+    jest.spyOn(UserPreferencesStateService.getInstance(), "activeSessionHasFeedback").mockReturnValueOnce(false);
+
+    // WHEN the component is rendered
+    renderWithProvider(givenComponent);
+
+    // AND the experiences drawer button is clicked
     const experiencesDrawerButton = screen.getByTestId(DATA_TEST_ID.EXPERIENCES_DRAWER_BUTTON);
     await userEvent.click(experiencesDrawerButton);
 
-    // THEN expect notifyOnExperiencesDrawerOpen to have been called
-    expect(notifyOnExperiencesDrawerOpen).toHaveBeenCalled();
+    // THEN expect handleOpenExperiencesDrawer to have been called
+    expect(givenMockHandleOpenExperiencesDrawer).toHaveBeenCalledTimes(1);
   });
 
-  test("should call notifyOpenFeedbackForm when feedback button is clicked", async () => {
-    // GIVEN a FeedbackFormButton component
-    const notifyOpenFeedbackForm = jest.fn();
-    const givenComponent = (
-      <ConversationConclusionFooter
-        notifyOnFeedbackFormOpen={notifyOpenFeedbackForm}
-        notifyOnExperiencesDrawerOpen={jest.fn()}
-        isFeedbackSubmitted={false}
-        isFeedbackStarted={false}
-      />
-    );
+  test("should open feedback form when feedback button is clicked", async () => {
+    // GIVEN a ConversationConclusionFooter component
+    const givenComponent = <ConversationConclusionFooter />;
+    
+    // AND the user has not submitted feedback before
+    jest.spyOn(UserPreferencesStateService.getInstance(), "activeSessionHasFeedback").mockReturnValueOnce(false);
 
     // WHEN the component is rendered
-    render(givenComponent);
+    renderWithProvider(givenComponent);
 
-    // WHEN the feedback button is clicked
+    // AND the feedback button is clicked
     const feedbackButton = screen.getByTestId(DATA_TEST_ID.FEEDBACK_FORM_BUTTON);
     await userEvent.click(feedbackButton);
 
-    // THEN expect notifyOpenFeedbackForm to have been called
-    expect(notifyOpenFeedbackForm).toHaveBeenCalled();
+    // THEN expect the feedback form dialog to be open
+    expect(screen.getByTestId("feedback-form-dialog-c6ba52ec-c1de-46ac-950b-f5354c6785ac")).toBeInTheDocument();
   });
 
-  test("should show feedback request message when feedback is not started or submitted", () => {
-    // GIVEN no feedback has been started or submitted
-    const mockIsFeedbackSubmitted = false;
-    const mockIsFeedbackInProgress = false;
+  test("should maintain feedback status when form is closed", async () => {
+    // GIVEN a ConversationConclusionFooter component
+    const givenComponent = <ConversationConclusionFooter />;
+    
+    // AND the user has not submitted feedback before
+    jest.spyOn(UserPreferencesStateService.getInstance(), "activeSessionHasFeedback").mockReturnValueOnce(false);
 
     // WHEN the component is rendered
-    render(
-      <ConversationConclusionFooter
-        notifyOnFeedbackFormOpen={jest.fn()}
-        notifyOnExperiencesDrawerOpen={jest.fn()}
-        isFeedbackSubmitted={mockIsFeedbackSubmitted}
-        isFeedbackStarted={mockIsFeedbackInProgress}
-      />
-    );
+    renderWithProvider(givenComponent);
+
+    // AND the feedback button is clicked
+    const feedbackButton = screen.getByTestId(DATA_TEST_ID.FEEDBACK_FORM_BUTTON);
+    await userEvent.click(feedbackButton);
+
+    // AND the form is closed
+    const closeButton = screen.getByTestId("feedback-form-dialog-button-c6ba52ec-c1de-46ac-950b-f5354c6785ac");
+    await userEvent.click(closeButton);
+
+    // THEN expect the feedback status to remain unchanged
+    expect(givenMockSetFeedbackStatus).not.toHaveBeenCalled();
+  });
+
+  test("should show feedback request message when feedback is not started", () => {
+    // GIVEN no feedback has been started
+    // AND the user has not submitted feedback before
+    jest.spyOn(UserPreferencesStateService.getInstance(), "activeSessionHasFeedback").mockReturnValueOnce(false);
+
+    // WHEN the component is rendered
+    renderWithProvider(<ConversationConclusionFooter />);
 
     // THEN expect the feedback message to be displayed
     expect(screen.getByTestId(DATA_TEST_ID.FEEDBACK_MESSAGE_TEXT)).toBeInTheDocument();
-    // AND the button to give feedback to be displayed
+    // AND expect the button to give feedback to be displayed
     expect(screen.getByTestId(DATA_TEST_ID.FEEDBACK_FORM_BUTTON)).toBeInTheDocument();
   });
 
   test("should show feedback in progress message when feedback is started but not submitted", () => {
     // GIVEN a feedback is in progress
-    const mockIsFeedbackInProgress = true;
+    const mockFeedbackItems: FeedbackItem[] = [
+      {
+        question_id: "overall_satisfaction",
+        answer: {
+          rating_numeric: 4,
+          comment: "Very helpful conversation!",
+        },
+        is_answered: true,
+      },
+      {
+        question_id: "ui_experience",
+        answer: {
+          rating_numeric: 5,
+        },
+        is_answered: true,
+      },
+    ];
+    (PersistentStorageService.getOverallFeedback as jest.Mock).mockReturnValue(mockFeedbackItems);
+
+    // AND the user has not submitted feedback before
+    jest.spyOn(UserPreferencesStateService.getInstance(), "activeSessionHasFeedback").mockReturnValueOnce(false);
 
     // WHEN the component is rendered
-    render(
-      <ConversationConclusionFooter
-        notifyOnFeedbackFormOpen={jest.fn()}
-        notifyOnExperiencesDrawerOpen={jest.fn()}
-        isFeedbackSubmitted={false}
-        isFeedbackStarted={mockIsFeedbackInProgress}
-      />
-    );
+    renderWithProvider(<ConversationConclusionFooter />);
 
     // THEN expect the feedback in progress message to be displayed
     expect(screen.getByTestId(DATA_TEST_ID.FEEDBACK_IN_PROGRESS_MESSAGE)).toBeInTheDocument();
@@ -143,19 +169,13 @@ describe("FeedbackFormButton", () => {
     expect(screen.getByTestId(DATA_TEST_ID.FEEDBACK_IN_PROGRESS_BUTTON)).toBeInTheDocument();
   });
 
-  test("should show thank you message when the user has submitted feedback", () => {
-    // GIVEN the user has submitted feedback
-    const mockIsFeedbackSubmitted = true;
+  test("should show thank you message when feedback is submitted", () => {
+    // GIVEN feedback has been submitted
+    // AND the user has submitted feedback before
+    jest.spyOn(UserPreferencesStateService.getInstance(), "activeSessionHasFeedback").mockReturnValueOnce(true);
 
     // WHEN the component is rendered
-    render(
-      <ConversationConclusionFooter
-        notifyOnFeedbackFormOpen={jest.fn()}
-        notifyOnExperiencesDrawerOpen={jest.fn()}
-        isFeedbackSubmitted={mockIsFeedbackSubmitted}
-        isFeedbackStarted={false}
-      />
-    );
+    renderWithProvider(<ConversationConclusionFooter />);
 
     // THEN expect the thank you message to be displayed
     expect(screen.getByTestId(DATA_TEST_ID.THANK_YOU_MESSAGE)).toBeInTheDocument();

--- a/frontend-new/src/chat/chatMessage/conversationConclusionChatMessage/conversationConclusionFooter/ConversationConclusionFooter.tsx
+++ b/frontend-new/src/chat/chatMessage/conversationConclusionChatMessage/conversationConclusionFooter/ConversationConclusionFooter.tsx
@@ -1,14 +1,14 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { Box, Typography, useTheme } from "@mui/material";
 import CustomLink from "src/theme/CustomLink/CustomLink";
 import { FIXED_MESSAGES_TEXT } from "src/chat/util";
-
-interface FeedbackFormButtonProps {
-  notifyOnFeedbackFormOpen: () => void;
-  notifyOnExperiencesDrawerOpen: () => void;
-  isFeedbackSubmitted: boolean;
-  isFeedbackStarted: boolean;
-}
+import FeedbackForm, { FeedbackStatus, FeedbackCloseEvent } from "src/feedback/overallFeedback/feedbackForm/FeedbackForm";
+import { useChatContext } from "src/chat/ChatContext";
+import UserPreferencesStateService from "src/userPreferences/UserPreferencesStateService";
+import {
+  FeedbackItem
+} from "src/feedback/overallFeedback/overallFeedbackService/OverallFeedback.service.types";
+import { PersistentStorageService } from "src/app/PersistentStorageService/PersistentStorageService";
 
 const uniqueId = "41675f8b-257c-4a63-9563-3fe9feb6a850";
 
@@ -22,26 +22,51 @@ export const DATA_TEST_ID = {
   THANK_YOU_MESSAGE: `thank-you-message-${uniqueId}`,
 };
 
-const ConversationConclusionFooter: React.FC<FeedbackFormButtonProps> = ({
-  notifyOnFeedbackFormOpen,
-  notifyOnExperiencesDrawerOpen,
-  isFeedbackSubmitted,
-  isFeedbackStarted,
-}) => {
+const ConversationConclusionFooter: React.FC = () => {
   const theme = useTheme();
+  const { feedbackStatus, setFeedbackStatus, handleOpenExperiencesDrawer } = useChatContext();
+
+  const [feedbackData, setFeedbackData] = useState<FeedbackItem[]>(PersistentStorageService.getOverallFeedback());
+  const [sessionHasFeedback, setSessionHasFeedback] = useState<boolean>(
+    UserPreferencesStateService.getInstance().activeSessionHasFeedback()
+  );
+  const [isFeedbackFormOpen, setIsFeedbackFormOpen] = useState<boolean>(false);
+
+  // Check local storage when the form is closed to see if there is saved feedback
+  useEffect(() => {
+    if (!isFeedbackFormOpen) {
+      const updatedFeedbackData = PersistentStorageService.getOverallFeedback();
+      if (JSON.stringify(feedbackData) !== JSON.stringify(updatedFeedbackData)) {
+        setFeedbackData(updatedFeedbackData);
+        // If there is feedback data, set the feedback status to started
+        if (updatedFeedbackData.length > 0 && feedbackStatus === FeedbackStatus.NOT_STARTED) {
+          setFeedbackStatus(FeedbackStatus.STARTED);
+        }
+      }
+    }
+  }, [isFeedbackFormOpen, feedbackData, feedbackStatus, setFeedbackStatus]);
+
+  // Update feedback status based on session feedback state
+  useEffect(() => {
+    if (sessionHasFeedback) {
+      setFeedbackStatus(FeedbackStatus.SUBMITTED)
+    } else if(feedbackData.length > 0) {
+      setFeedbackStatus(FeedbackStatus.STARTED)
+    }
+  }, [feedbackData.length, sessionHasFeedback, setFeedbackStatus]);
 
   let feedbackMessage;
-  if (isFeedbackSubmitted) {
+  if (sessionHasFeedback || feedbackStatus === FeedbackStatus.SUBMITTED) {
     feedbackMessage = (
       <Typography variant="body1" data-testid={DATA_TEST_ID.THANK_YOU_MESSAGE}>
         {FIXED_MESSAGES_TEXT.THANK_YOU}
       </Typography>
     );
-  } else if (isFeedbackStarted) {
+  } else if (feedbackStatus === FeedbackStatus.STARTED) {
     feedbackMessage = (
       <Typography variant="body1" data-testid={DATA_TEST_ID.FEEDBACK_IN_PROGRESS_MESSAGE}>
         Please{" "}
-        <CustomLink onClick={notifyOnFeedbackFormOpen} data-testid={DATA_TEST_ID.FEEDBACK_IN_PROGRESS_BUTTON}>
+        <CustomLink onClick={() => setIsFeedbackFormOpen(true)} data-testid={DATA_TEST_ID.FEEDBACK_IN_PROGRESS_BUTTON}>
           complete your feedback
         </CustomLink>{" "}
         to help us improve your experience!
@@ -51,7 +76,7 @@ const ConversationConclusionFooter: React.FC<FeedbackFormButtonProps> = ({
     feedbackMessage = (
       <Typography variant="body1" data-testid={DATA_TEST_ID.FEEDBACK_MESSAGE_TEXT}>
         We'd love your{" "}
-        <CustomLink onClick={notifyOnFeedbackFormOpen} data-testid={DATA_TEST_ID.FEEDBACK_FORM_BUTTON}>
+        <CustomLink onClick={() => setIsFeedbackFormOpen(true)} data-testid={DATA_TEST_ID.FEEDBACK_FORM_BUTTON}>
           feedback
         </CustomLink>{" "}
         on this chat. It only takes 5 minutes and helps us improve!
@@ -59,25 +84,45 @@ const ConversationConclusionFooter: React.FC<FeedbackFormButtonProps> = ({
     );
   }
 
-  return (
-    <Box
-      display="flex"
-      flexDirection="column"
-      justifyContent="start"
-      gap={theme.fixedSpacing(theme.tabiyaSpacing.md)}
-      marginTop={theme.fixedSpacing(theme.tabiyaSpacing.md)}
-      data-testid={DATA_TEST_ID.CONVERSATION_CONCLUSION_FOOTER_CONTAINER}
-    >
-      <Typography variant="body1">
-        Don't forget to{" "}
-        <CustomLink onClick={notifyOnExperiencesDrawerOpen} data-testid={DATA_TEST_ID.EXPERIENCES_DRAWER_BUTTON}>
-          <span style={{ whiteSpace: "normal" }}>view and download your CV</span>
-        </CustomLink>
-        !
-      </Typography>
+  const handleFeedbackFormClose = (closeEvent: FeedbackCloseEvent) => {
+    setIsFeedbackFormOpen(false);
+    if (closeEvent === FeedbackCloseEvent.SUBMIT) {
+      setFeedbackStatus(FeedbackStatus.SUBMITTED);
+      setSessionHasFeedback(true);
+    } else if (closeEvent === FeedbackCloseEvent.DISMISS) {
+      if (feedbackData.length > 0) {
+        setFeedbackStatus(FeedbackStatus.STARTED);
+      } else {
+        setFeedbackStatus(FeedbackStatus.NOT_STARTED);
+      }
+    }
+  }
 
-      {feedbackMessage}
-    </Box>
+  return (
+    <>
+      <Box
+        display="flex"
+        flexDirection="column"
+        justifyContent="start"
+        gap={theme.fixedSpacing(theme.tabiyaSpacing.md)}
+        marginTop={theme.fixedSpacing(theme.tabiyaSpacing.md)}
+        data-testid={DATA_TEST_ID.CONVERSATION_CONCLUSION_FOOTER_CONTAINER}
+      >
+        <Typography variant="body1">
+          Don't forget to{" "}
+          <CustomLink onClick={handleOpenExperiencesDrawer} data-testid={DATA_TEST_ID.EXPERIENCES_DRAWER_BUTTON}>
+            <span style={{ whiteSpace: "normal" }}>view and download your CV</span>
+          </CustomLink>
+          !
+        </Typography>
+
+        {feedbackMessage}
+      </Box>
+      <FeedbackForm
+        isOpen={isFeedbackFormOpen}
+        notifyOnClose={handleFeedbackFormClose}
+      />
+    </>
   );
 };
 

--- a/frontend-new/src/chat/chatMessage/conversationConclusionChatMessage/conversationConclusionFooter/__snapshots__/ConversationConclusionFooter.test.tsx.snap
+++ b/frontend-new/src/chat/chatMessage/conversationConclusionChatMessage/conversationConclusionFooter/__snapshots__/ConversationConclusionFooter.test.tsx.snap
@@ -1,10 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FeedbackFormButton should render component successfully 1`] = `
-<a
-  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1vjgeqq-MuiTypography-root-MuiLink-root"
-  data-testid="feedback-form-button-41675f8b-257c-4a63-9563-3fe9feb6a850"
+exports[`ConversationConclusionFooter should render component successfully 1`] = `
+<div
+  class="MuiBox-root css-z3t5d1"
+  data-testid="feedback-form-button-container-41675f8b-257c-4a63-9563-3fe9feb6a850"
 >
-  feedback
-</a>
+  <p
+    class="MuiTypography-root MuiTypography-body1 css-1czz4sp-MuiTypography-root"
+  >
+    Don't forget to
+     
+    <a
+      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1vjgeqq-MuiTypography-root-MuiLink-root"
+      data-testid="feedback-form-experiences-drawer-button-41675f8b-257c-4a63-9563-3fe9feb6a850"
+    >
+      <span
+        style="white-space: normal;"
+      >
+        view and download your CV
+      </span>
+    </a>
+    !
+  </p>
+  <p
+    class="MuiTypography-root MuiTypography-body1 css-1czz4sp-MuiTypography-root"
+    data-testid="feedback-message-text-41675f8b-257c-4a63-9563-3fe9feb6a850"
+  >
+    We'd love your
+     
+    <a
+      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1vjgeqq-MuiTypography-root-MuiLink-root"
+      data-testid="feedback-form-button-41675f8b-257c-4a63-9563-3fe9feb6a850"
+    >
+      feedback
+    </a>
+     
+    on this chat. It only takes 5 minutes and helps us improve!
+  </p>
+</div>
 `;

--- a/frontend-new/src/feedback/overallFeedback/feedbackForm/FeedbackForm.test.tsx
+++ b/frontend-new/src/feedback/overallFeedback/feedbackForm/FeedbackForm.test.tsx
@@ -1,7 +1,7 @@
 // mute the console
 import "src/_test_utilities/consoleMock";
 
-import FeedbackForm, { DATA_TEST_ID } from "src/feedback/overallFeedback/feedbackForm/FeedbackForm";
+import FeedbackForm, { DATA_TEST_ID, FeedbackCloseEvent } from "src/feedback/overallFeedback/feedbackForm/FeedbackForm";
 import { render, screen } from "src/_test_utilities/test-utils";
 import { fireEvent, waitFor } from "@testing-library/react";
 import { DATA_TEST_ID as FEEDBACK_FORM_CONTENT_DATA_TEST_ID } from "src/feedback/overallFeedback/feedbackForm/components/feedbackFormContent/FeedbackFormContent";
@@ -44,7 +44,7 @@ jest.mock("src/userPreferences/UserPreferencesStateService", () => ({
 describe("FeedbackForm", () => {
   test("should render component successfully", () => {
     // GIVEN the component
-    const givenFeedbackForm = <FeedbackForm isOpen={true} notifyOnClose={jest.fn()} onFeedbackSubmit={jest.fn()} />;
+    const givenFeedbackForm = <FeedbackForm isOpen={true} notifyOnClose={jest.fn()} />;
 
     // WHEN the component is rendered
     render(givenFeedbackForm);
@@ -71,7 +71,7 @@ describe("FeedbackForm", () => {
     // GIVEN the component
     const mockHandleClose = jest.fn();
     const givenFeedbackForm = (
-      <FeedbackForm isOpen={true} notifyOnClose={mockHandleClose} onFeedbackSubmit={jest.fn()} />
+      <FeedbackForm isOpen={true} notifyOnClose={mockHandleClose} />
     );
     // AND the component is rendered
     render(givenFeedbackForm);
@@ -96,7 +96,7 @@ describe("FeedbackForm", () => {
       // GIVEN the component
       const mockHandleClose = jest.fn();
       const givenFeedbackForm = (
-        <FeedbackForm isOpen={true} notifyOnClose={mockHandleClose} onFeedbackSubmit={jest.fn()} />
+        <FeedbackForm isOpen={true} notifyOnClose={mockHandleClose} />
       );
       // AND the component is rendered
       render(givenFeedbackForm);
@@ -111,9 +111,9 @@ describe("FeedbackForm", () => {
       }
 
       // THEN expect the notifyOnClose to have been called
-      expect(mockHandleClose).toHaveBeenCalled();
+      await waitFor(() => expect(mockHandleClose).toHaveBeenCalledWith(FeedbackCloseEvent.SUBMIT));
       // AND the sendFeedback function to have been called
-      await waitFor(() => expect(mockSendFeedback).toHaveBeenCalled());
+      expect(mockSendFeedback).toHaveBeenCalled();
       // AND the snackbar to have been called
       await waitFor(() =>
         expect(useSnackbar().enqueueSnackbar).toHaveBeenCalledWith("Feedback submitted successfully!", {
@@ -137,7 +137,7 @@ describe("FeedbackForm", () => {
       });
 
       // WHEN the component is rendered
-      render(<FeedbackForm isOpen={true} notifyOnClose={jest.fn()} onFeedbackSubmit={jest.fn()} />);
+      render(<FeedbackForm isOpen={true} notifyOnClose={jest.fn()} />);
       // AND there is at least one answer
       const input = screen.getAllByTestId(COMMENT_TEXT_FIELD_TEST_ID.COMMENT_TEXT_FIELD);
       fireEvent.change(input[0], { target: { value: "This is a comment" } });

--- a/frontend-new/src/feedback/overallFeedback/feedbackForm/FeedbackForm.tsx
+++ b/frontend-new/src/feedback/overallFeedback/feedbackForm/FeedbackForm.tsx
@@ -13,12 +13,18 @@ import { FeedbackError } from "src/error/commonErrors";
 
 export interface FeedbackFormProps {
   isOpen: boolean;
-  notifyOnClose: (event: { name: CloseEventName }) => void;
-  onFeedbackSubmit: () => void;
+  notifyOnClose: (event: FeedbackCloseEvent) => void;
 }
 
-export enum CloseEventName {
+export enum FeedbackStatus {
+  STARTED="STARTED",
+  NOT_STARTED= "NOT_STARTED",
+  SUBMITTED= "SUBMITTED",
+}
+
+export enum FeedbackCloseEvent {
   DISMISS = "DISMISS",
+  SUBMIT = "SUBMIT"
 }
 
 const uniqueId = "c6ba52ec-c1de-46ac-950b-f5354c6785ac";
@@ -31,19 +37,19 @@ export const DATA_TEST_ID = {
   FEEDBACK_FORM_DIALOG_CONTENT: `feedback-form-dialog-content-${uniqueId}`,
 };
 
-const FeedbackForm: React.FC<FeedbackFormProps> = ({ isOpen, notifyOnClose, onFeedbackSubmit }) => {
+const FeedbackForm: React.FC<FeedbackFormProps> = ({ isOpen, notifyOnClose }) => {
   const theme = useTheme();
   const { enqueueSnackbar } = useSnackbar();
   const isSmallMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down("sm"));
   const [isSubmitting, setIsSubmitting] = React.useState(false);
 
   const handleClose = () => {
-    notifyOnClose({ name: CloseEventName.DISMISS });
+    notifyOnClose(FeedbackCloseEvent.DISMISS);
   };
 
   const handleFeedbackSubmit = async (formData: FeedbackItem[]): Promise<void> => {
     setIsSubmitting(true);
-    handleClose();
+    notifyOnClose(FeedbackCloseEvent.SUBMIT)
     try {
       const userPreferences = UserPreferencesStateService.getInstance().getUserPreferences();
       if (!userPreferences?.sessions.length) {
@@ -55,7 +61,6 @@ const FeedbackForm: React.FC<FeedbackFormProps> = ({ isOpen, notifyOnClose, onFe
       await overallFeedbackService.sendFeedback(formData);
 
       enqueueSnackbar("Feedback submitted successfully!", { variant: "success" });
-      onFeedbackSubmit();
     } catch (error) {
       console.error(new FeedbackError("Failed to submit feedback", error as Error));
       enqueueSnackbar("Failed to submit feedback. Please try again later.", { variant: "error" });


### PR DESCRIPTION
…ng props

- move FeedbackForm.tsx call to ConversationConclusionFooter and move tests accordingly