### PR TITLE
feat(backend): export metrics script support work-types changes.

### DIFF
--- a/backend/scripts/_old/logging.cfg.yaml
+++ b/backend/scripts/_old/logging.cfg.yaml
@@ -1,0 +1,16 @@
+version: 1
+disable_existing_loggers: false
+
+formatters:
+  default:
+    format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
+handlers:
+  console:
+    (): logging.StreamHandler
+    formatter: default
+    stream: ext://sys.stdout
+
+root:
+  level: INFO
+  handlers: [console]


### PR DESCRIPTION
If there exist an event of ExperiencesDiscovered without work_types explored, the event is upserted