### PR TITLE
fix(frontend): replace Sentry user context with tags for user and ses…

### DIFF
--- a/backend/app/sentry_init.py
+++ b/backend/app/sentry_init.py
@@ -41,8 +41,6 @@ def set_sentry_contexts():
 
 def attach_ticket_info(event: Event, hint: Hint) -> Event | None:
     # Set default user context with values from context vars
-    sentry_sdk.set_user({
-        "session_id": session_id_ctx_var.get(),
-        "user_id": user_id_ctx_var.get()
-    })
+    sentry_sdk.set_tag("session_id", session_id_ctx_var.get())
+    sentry_sdk.set_tag("user_id", user_id_ctx_var.get())
     return event

--- a/frontend-new/src/auth/services/AuthenticationState.service.test.ts
+++ b/frontend-new/src/auth/services/AuthenticationState.service.test.ts
@@ -15,11 +15,6 @@ jest.mock("src/app/PersistentStorageService/PersistentStorageService", () => ({
   },
 }));
 
-// Mock Sentry
-jest.mock("@sentry/react", () => ({
-  setUser: jest.fn(),
-}));
-
 function getMockTabiyaUser(): TabiyaUser {
   return {
     id: nanoid(), // ensure a unique user id
@@ -88,56 +83,25 @@ describe("AuthenticationStateService", () => {
       it("should set the user and update Sentry", () => {
         // GIVEN a user
         const givenUser = getMockTabiyaUser();
-        const setUserSpy = jest.spyOn(require("@sentry/react"), "setUser");
+        // const setTagSpy = jest.spyOn(require("@sentry/react"), "setTag");
 
         // WHEN setUser is called
         const result = service.setUser(givenUser);
 
         // THEN expect the user to be set
         expect(service.getUser()).toEqual(givenUser);
-        // AND expect Sentry to be updated
-        expect(setUserSpy).toHaveBeenCalledWith({
-          user_id: givenUser.id
-        });
         // AND expect the result to be the user
         expect(result).toEqual(givenUser);
       });
 
       it("should handle null user and update Sentry", () => {
-        // GIVEN a null user
-        const setUserSpy = jest.spyOn(require("@sentry/react"), "setUser");
-
         // WHEN setUser is called with null
         const result = service.setUser(null);
 
         // THEN expect the user to be null
         expect(service.getUser()).toBeNull();
-        // AND expect Sentry to be updated with UNKNOWN
-        expect(setUserSpy).toHaveBeenCalledWith({
-          user_id: "UNKNOWN"
-        });
         // AND expect the result to be null
         expect(result).toBeNull();
-      });
-
-      it("should handle Sentry errors gracefully", () => {
-        // GIVEN a user
-        const givenUser = getMockTabiyaUser();
-        // AND Sentry.setUser will throw an error
-        jest.spyOn(require("@sentry/react"), "setUser").mockImplementationOnce(() => {
-          throw new Error("Sentry error");
-        });
-        const consoleErrorSpy = jest.spyOn(console, "error");
-
-        // WHEN setUser is called
-        const result = service.setUser(givenUser);
-
-        // THEN expect the user to be set despite the error
-        expect(service.getUser()).toEqual(givenUser);
-        // AND expect the error to be logged
-        expect(consoleErrorSpy).toHaveBeenCalledWith("Error setting Sentry user context", expect.any(Error));
-        // AND expect the result to be the user
-        expect(result).toEqual(givenUser);
       });
     });
 

--- a/frontend-new/src/auth/services/AuthenticationState.service.ts
+++ b/frontend-new/src/auth/services/AuthenticationState.service.ts
@@ -1,6 +1,5 @@
 import { TabiyaUser } from "src/auth/auth.types";
 import { PersistentStorageService } from "src/app/PersistentStorageService/PersistentStorageService";
-import * as Sentry from "@sentry/react";
 
 /**
  * AuthenticationStateService manages the authentication state of the application.
@@ -65,14 +64,6 @@ export default class AuthenticationStateService {
    */
   public setUser(user: TabiyaUser | null): TabiyaUser | null {
     this.user = user;
-    // Set the session context for Sentry so that we can track the user id in errors
-    try {
-      Sentry.setUser({
-        user_id: user?.id ?? "UNKNOWN",
-      });
-    } catch (err) {
-      console.error("Error setting Sentry user context", err);
-    }
     return this.user;
   }
 

--- a/frontend-new/src/sentryInit.ts
+++ b/frontend-new/src/sentryInit.ts
@@ -4,6 +4,8 @@ import React from "react";
 import { createRoutesFromChildren, matchRoutes, useLocation, useNavigationType } from "react-router-dom";
 import { serializeError } from "./error/errorSerializer";
 import InfoService from "./info/info.service";
+import AuthenticationStateService from "./auth/services/AuthenticationState.service";
+import UserPreferencesStateService from "./userPreferences/UserPreferencesStateService";
 
 export interface SentryConfig {
   // See https://docs.sentry.io/platforms/javascript/configuration/options/
@@ -127,6 +129,11 @@ export function initSentry() {
           ...event.extra,
           errorDetails: serialized,
         };
+        event.tags = {
+          ...event.tags,
+          user_id: AuthenticationStateService.getInstance().getUser()?.id,
+          session_id: UserPreferencesStateService.getInstance().getActiveSessionId()
+        }
       }
       return event;
     },

--- a/frontend-new/src/userPreferences/UserPreferencesStateService.ts
+++ b/frontend-new/src/userPreferences/UserPreferencesStateService.ts
@@ -2,7 +2,6 @@ import { SensitivePersonalDataRequirement, UserPreference, Language } from "src/
 import {
   QUESTION_KEYS,
 } from "src/feedback/overallFeedback/overallFeedbackService/OverallFeedback.service.types";
-import * as Sentry from "@sentry/react";
 
 export default class UserPreferencesStateService {
   private static instance: UserPreferencesStateService;
@@ -41,14 +40,6 @@ export default class UserPreferencesStateService {
   public setUserPreferences(preferences: UserPreference): void {
     // Store a deep copy of the user preferences object to prevent direct modification
     this.userPreferences = this.cloneUserPreferences(preferences);
-    try {
-      // Set the session context for Sentry so that we can track the session id in errors
-      Sentry.setContext("session", {
-        session_id: this.getActiveSessionId() ?? "UNKNOWN"
-      });
-    } catch (err) {
-      console.error(new Error(`Failed to set sentry context`, { cause: err }));
-    }
   }
 
   public clearUserPreferences(): void {


### PR DESCRIPTION
…sion tracking

- set the session and user ids on beforeSend instead of in the state services